### PR TITLE
Children disability data not loaded properly

### DIFF
--- a/src/main/routes/features/response/statementOfMeans/dependants/childrenDisabilityController.ts
+++ b/src/main/routes/features/response/statementOfMeans/dependants/childrenDisabilityController.ts
@@ -25,8 +25,13 @@ childrenDisabilityController
     async (req: express.Request, res: express.Response) => {
       try {
         const childrenDisability : ChildrenDisability = await getChildrenDisability(req.params.id);
+        const form = new GenericForm(childrenDisability);
+        // This is a workaround as the YesNo macro used in the view assumes Form but controller assumes GenericForm
+        // TODO: Discard the workaround once the decision Form Vs. GenericForm is made and YesNo macro is adjusted accordingly
+        const _form = Object.assign(form);
+        _form.option = childrenDisability.option;
         res.render(childrenDisabilityViewPath,{
-          form: new GenericForm(childrenDisability),
+          form: _form,
         });
       } catch (error) {
         logger.error(error);


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/CIV-2038

### Change description ###

Fix to Children disability data not loaded properly. This was due to the fact that YesNo macro used in the view assumes Form but controller assumes GenericForm

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
