### PR TITLE
CIV-2041 Tech Debt - Reusable Mocks

### DIFF
--- a/src/main/common/form/validationErrors/errorMessageConstants.ts
+++ b/src/main/common/form/validationErrors/errorMessageConstants.ts
@@ -31,7 +31,6 @@ export const VALID_POSITIVE_NUMBER = 'Don’t enter a negative number';
 export const VALID_BETWEEN_NUMBERS_0_11 = 'Enter a number between 0 and 11';
 export const VALID_BETWEEN_NUMBERS_0_80 = 'Enter a number between 0 and 80';
 export const VALID_NUMBER_FOR_PREVIOUS_PAGE = 'Number can’t be higher than on previous page';
-export const REDIS_ERROR_MESSAGE = 'Redis DraftStore failure.';
 export const VALID_YES_NO_SELECTION = 'Please select yes or no';
 export const VALID_ENTER_AT_LEAST_ONE_NUMBER = 'Enter a number for at least one field';
 export const AMOUNT_INVALID_DECIMALS = 'Enter a valid amount, maximum two decimal places';

--- a/src/test/unit/modules/admission/fullAdmission/paymentOption/paymentOptionService.test.ts
+++ b/src/test/unit/modules/admission/fullAdmission/paymentOption/paymentOptionService.test.ts
@@ -6,14 +6,14 @@ import {
 } from '../../../../../../main/modules/admission/fullAdmission/paymentOption/paymentOptionService';
 import PaymentOptionType
   from '../../../../../../main/common/form/models/admission/fullAdmission/paymentOption/paymentOptionType';
-import {REDIS_ERROR_MESSAGE} from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import PaymentOption
   from '../../../../../../main/common/form/models/admission/fullAdmission/paymentOption/paymentOption';
-
+import {TestMessages} from '../../../../../utils/errorMessageTestConstants';
 
 jest.mock('../../../../../../main/modules/draft-store');
 jest.mock('../../../../../../main/modules/draft-store/draftStoreService');
 const mockGetCaseData = draftStoreService.getCaseDataFromStore as jest.Mock;
+
 describe('payment option service', () => {
   describe('get payment option form', () => {
     it('should get populated form when data exists', async () => {
@@ -64,10 +64,10 @@ describe('payment option service', () => {
     it('should throw an error when error is thrown from draft store', async () => {
       //When
       mockGetCaseData.mockImplementation(async () => {
-        throw new Error(REDIS_ERROR_MESSAGE);
+        throw new Error(TestMessages.REDIS_FAILURE);
       });
       //Then
-      await expect(getPaymentOptionForm('123')).rejects.toThrow(REDIS_ERROR_MESSAGE);
+      await expect(getPaymentOptionForm('123')).rejects.toThrow(TestMessages.REDIS_FAILURE);
     });
   });
   describe('save payment option', () => {
@@ -98,10 +98,10 @@ describe('payment option service', () => {
       const mockSaveClaim = draftStoreService.saveDraftClaim as jest.Mock;
       //When
       mockSaveClaim.mockImplementation(async () => {
-        throw new Error(REDIS_ERROR_MESSAGE);
+        throw new Error(TestMessages.REDIS_FAILURE);
       });
       //Then
-      await expect(savePaymentOptionData('123', new PaymentOption(PaymentOptionType.BY_SET_DATE))).rejects.toThrow(REDIS_ERROR_MESSAGE);
+      await expect(savePaymentOptionData('123', new PaymentOption(PaymentOptionType.BY_SET_DATE))).rejects.toThrow(TestMessages.REDIS_FAILURE);
     });
   });
 });

--- a/src/test/unit/modules/statementOfMeans/dependants/betweenSixteenAndNineteenService.test.ts
+++ b/src/test/unit/modules/statementOfMeans/dependants/betweenSixteenAndNineteenService.test.ts
@@ -10,12 +10,12 @@ import {Claim} from '../../../../../main/common/models/claim';
 import {StatementOfMeans} from '../../../../../main/common/models/statementOfMeans';
 import {NumberOfChildren} from '../../../../../main/common/form/models/statementOfMeans/dependants/numberOfChildren';
 import {Dependants} from '../../../../../main/common/form/models/statementOfMeans/dependants/dependants';
-import {REDIS_ERROR_MESSAGE} from '../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {TestMessages} from '../../../../utils/errorMessageTestConstants';
 
 jest.mock('../../../../../main/modules/draft-store');
 jest.mock('../../../../../main/modules/draft-store/draftStoreService');
-describe('dependent teenagers service test', () => {
 
+describe('dependent teenagers service test', () => {
   describe('saveFormToDraftStore', () => {
     it('should save data successfully', async () => {
       //Given
@@ -29,10 +29,10 @@ describe('dependent teenagers service test', () => {
       //When
       const mockGetCaseData = draftStoreService.saveDraftClaim as jest.Mock;
       mockGetCaseData.mockImplementation(async () => {
-        throw new Error(REDIS_ERROR_MESSAGE);
+        throw new Error(TestMessages.REDIS_FAILURE);
       });
       //Then
-      await expect(saveFormToDraftStore('123', new BetweenSixteenAndNineteenDependants(3, 4))).rejects.toThrow(REDIS_ERROR_MESSAGE);
+      await expect(saveFormToDraftStore('123', new BetweenSixteenAndNineteenDependants(3, 4))).rejects.toThrow(TestMessages.REDIS_FAILURE);
     });
   });
   describe('getForm', () => {
@@ -75,10 +75,10 @@ describe('dependent teenagers service test', () => {
       //When
       const mockGetCaseData = draftStoreService.getCaseDataFromStore as jest.Mock;
       mockGetCaseData.mockImplementation(async () => {
-        throw new Error(REDIS_ERROR_MESSAGE);
+        throw new Error(TestMessages.REDIS_FAILURE);
       });
       //Then
-      await expect(getForm('123')).rejects.toThrow(REDIS_ERROR_MESSAGE);
+      await expect(getForm('123')).rejects.toThrow(TestMessages.REDIS_FAILURE);
     });
   });
 });

--- a/src/test/unit/routes/features/response/admission/fullAdmission/paymentOption/paymentOptionController.test.ts
+++ b/src/test/unit/routes/features/response/admission/fullAdmission/paymentOption/paymentOptionController.test.ts
@@ -11,23 +11,10 @@ import {
   REDIS_ERROR_MESSAGE,
   VALID_PAYMENT_OPTION,
 } from '../../../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {mockCivilClaim, mockRedisFailure} from '../../../../../../../utils/mockDraftStore';
 
 jest.mock('../../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../../main/modules/draft-store');
-const mockDraftStore = {
-  get: jest.fn(() => Promise.resolve('{}')),
-  set: jest.fn(() => Promise.resolve()),
-};
-
-const mockGetExceptionDraftStore = {
-  get: jest.fn(() => {
-    throw new Error(REDIS_ERROR_MESSAGE);
-  }),
-  set: jest.fn(() => {
-    throw new Error(REDIS_ERROR_MESSAGE);
-  }),
-};
-
 
 describe('Payment Option Controller', () => {
   const citizenRoleToken: string = config.get('citizenRoleToken');
@@ -39,7 +26,7 @@ describe('Payment Option Controller', () => {
   });
   describe('on Get', () => {
     beforeEach(() => {
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
     });
     test('should return payment option page successfully', async () => {
       await request(app)
@@ -50,7 +37,7 @@ describe('Payment Option Controller', () => {
         });
     });
     test('should return status 500 when there is an error', async () => {
-      app.locals.draftStoreClient = mockGetExceptionDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .get(CITIZEN_PAYMENT_OPTION_URL)
         .expect((res) => {
@@ -61,7 +48,7 @@ describe('Payment Option Controller', () => {
   });
   describe('on Post', () => {
     beforeEach(() => {
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
     });
     test('should validate when option is not selected', async () => {
       await request(app)
@@ -100,7 +87,7 @@ describe('Payment Option Controller', () => {
         });
     });
     test('should return 500 status when there is error', async () => {
-      app.locals.draftStoreClient = mockGetExceptionDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .post(CITIZEN_PAYMENT_OPTION_URL)
         .send('paymentType=BY_SET_DATE')

--- a/src/test/unit/routes/features/response/admission/fullAdmission/paymentOption/paymentOptionController.test.ts
+++ b/src/test/unit/routes/features/response/admission/fullAdmission/paymentOption/paymentOptionController.test.ts
@@ -7,11 +7,9 @@ import {
   CITIZEN_PAYMENT_OPTION_URL,
   CLAIM_TASK_LIST_URL,
 } from '../../../../../../../../main/routes/urls';
-import {
-  REDIS_FAILURE,
-  VALID_PAYMENT_OPTION,
-} from '../../../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {VALID_PAYMENT_OPTION} from '../../../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import {mockCivilClaim, mockRedisFailure} from '../../../../../../../utils/mockDraftStore';
+import {TestMessages} from '../../../../../../../utils/errorMessageTestConstants';
 
 jest.mock('../../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../../main/modules/draft-store');
@@ -42,7 +40,7 @@ describe('Payment Option Controller', () => {
         .get(CITIZEN_PAYMENT_OPTION_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toMatchObject({error: REDIS_FAILURE});
+          expect(res.body).toMatchObject({error: TestMessages.REDIS_FAILURE});
         });
     });
   });
@@ -93,7 +91,7 @@ describe('Payment Option Controller', () => {
         .send('paymentType=BY_SET_DATE')
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toMatchObject({error: REDIS_FAILURE});
+          expect(res.body).toMatchObject({error: TestMessages.REDIS_FAILURE});
         });
     });
   });

--- a/src/test/unit/routes/features/response/admission/fullAdmission/paymentOption/paymentOptionController.test.ts
+++ b/src/test/unit/routes/features/response/admission/fullAdmission/paymentOption/paymentOptionController.test.ts
@@ -8,7 +8,7 @@ import {
   CLAIM_TASK_LIST_URL,
 } from '../../../../../../../../main/routes/urls';
 import {
-  REDIS_ERROR_MESSAGE,
+  REDIS_FAILURE,
   VALID_PAYMENT_OPTION,
 } from '../../../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import {mockCivilClaim, mockRedisFailure} from '../../../../../../../utils/mockDraftStore';
@@ -42,7 +42,7 @@ describe('Payment Option Controller', () => {
         .get(CITIZEN_PAYMENT_OPTION_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toMatchObject({error: REDIS_ERROR_MESSAGE});
+          expect(res.body).toMatchObject({error: REDIS_FAILURE});
         });
     });
   });
@@ -93,7 +93,7 @@ describe('Payment Option Controller', () => {
         .send('paymentType=BY_SET_DATE')
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toMatchObject({error: REDIS_ERROR_MESSAGE});
+          expect(res.body).toMatchObject({error: REDIS_FAILURE});
         });
     });
   });

--- a/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
@@ -92,8 +92,8 @@ describe('Confirm Details page', () => {
         expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
       });
   });
-  test('should return your details page with empty information', async () => {
 
+  test('should return your details page with empty information', async () => {
     mockGetRespondentInformation.mockImplementation(async () => {
       return new Respondent();
     });
@@ -104,8 +104,8 @@ describe('Confirm Details page', () => {
         expect(res.text).toContain('Confirm your details');
       });
   });
-  test('should return your details page with information', async () => {
 
+  test('should return your details page with information', async () => {
     mockGetRespondentInformation.mockImplementation(async () => {
       return buildClaimOfRespondent();
     });
@@ -116,6 +116,7 @@ describe('Confirm Details page', () => {
         expect(res.text).toContain('Confirm your details');
       });
   });
+
   test('should return your details page with information without correspondent address', async () => {
     const buildClaimOfRespondentWithoutCorrespondent = (): Respondent => {
       claim.respondent1 = new Respondent();
@@ -135,8 +136,8 @@ describe('Confirm Details page', () => {
         expect(res.text).toContain('Confirm your details');
       });
   });
-  test('POST/Citizen details - should redirect on correct primary address', async () => {
 
+  test('POST/Citizen details - should redirect on correct primary address', async () => {
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -158,7 +159,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should redirect on correct correspondence address', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -180,7 +180,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on empty primary address line', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -203,7 +202,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on empty primary city', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -226,7 +224,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on empty primary postcode', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -249,7 +246,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on empty correspondence address line', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -272,7 +268,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on empty correspondence city', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -295,7 +290,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on empty correspondence postcode', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -318,7 +312,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on no input', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -346,7 +339,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on input for primary address when postToThisAddress is set to NO', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -371,7 +363,6 @@ describe('Confirm Details page', () => {
   });
 
   test('POST/Citizen details - should return error on input for correspondence address when postToThisAddress is set to YES', async () => {
-
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send({
@@ -396,7 +387,6 @@ describe('Confirm Details page', () => {
   });
 
   test('get/Citizen details - should return test variable when there is no data on redis and civil-service', async () => {
-
     await request(app)
       .get('/case/1111/response/your-details')
       .expect((res) => {

--- a/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
@@ -9,7 +9,7 @@ import {
   VALID_CORRESPONDENCE_ADDRESS_LINE_1,
   VALID_CORRESPONDENCE_CITY,
   VALID_CORRESPONDENCE_POSTCODE,
-  REDIS_ERROR_MESSAGE,
+  REDIS_FAILURE,
 } from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import {
   getRespondentInformation,
@@ -69,27 +69,27 @@ describe('Confirm Details page', () => {
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
       mockGetRespondentInformation.mockImplementation(async () => {
-        throw new Error(REDIS_ERROR_MESSAGE);
+        throw new Error(REDIS_FAILURE);
       });
       await request(app)
         .get(CITIZEN_DETAILS_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
+          expect(res.body).toEqual({error: REDIS_FAILURE});
         });
     });
   });
 
   test('should return http 500 when has error in the post method', async () => {
     mockSaveRespondent.mockImplementation(async () => {
-      throw new Error(REDIS_ERROR_MESSAGE);
+      throw new Error(REDIS_FAILURE);
     });
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send(validDataForPost)
       .expect((res) => {
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
+        expect(res.body).toEqual({error: REDIS_FAILURE});
       });
   });
 

--- a/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
@@ -9,6 +9,7 @@ import {
   VALID_CORRESPONDENCE_ADDRESS_LINE_1,
   VALID_CORRESPONDENCE_CITY,
   VALID_CORRESPONDENCE_POSTCODE,
+  REDIS_ERROR_MESSAGE,
 } from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import {
   getRespondentInformation,
@@ -28,7 +29,6 @@ const mockSaveRespondent = saveRespondent as jest.Mock;
 
 const claim = new Claim();
 
-
 const buildClaimOfRespondent = (): Respondent => {
   claim.respondent1 = new Respondent();
   claim.respondent1.individualTitle = 'individualTitle';
@@ -40,7 +40,6 @@ const buildClaimOfRespondent = (): Respondent => {
 };
 
 const nock = require('nock');
-const redisFailureError = 'Redis DraftStore failure.';
 
 const validDataForPost = {
   primaryAddressLine1: 'Flat 3A Middle Road',
@@ -70,28 +69,27 @@ describe('Confirm Details page', () => {
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
       mockGetRespondentInformation.mockImplementation(async () => {
-        throw new Error(redisFailureError);
+        throw new Error(REDIS_ERROR_MESSAGE);
       });
       await request(app)
         .get(CITIZEN_DETAILS_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: redisFailureError});
+          expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
         });
     });
   });
 
   test('should return http 500 when has error in the post method', async () => {
-    const redisFailureError = 'Redis DraftStore failure.';
     mockSaveRespondent.mockImplementation(async () => {
-      throw new Error(redisFailureError);
+      throw new Error(REDIS_ERROR_MESSAGE);
     });
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send(validDataForPost)
       .expect((res) => {
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: redisFailureError});
+        expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
       });
   });
   test('should return your details page with empty information', async () => {

--- a/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
@@ -9,7 +9,6 @@ import {
   VALID_CORRESPONDENCE_ADDRESS_LINE_1,
   VALID_CORRESPONDENCE_CITY,
   VALID_CORRESPONDENCE_POSTCODE,
-  REDIS_FAILURE,
 } from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import {
   getRespondentInformation,
@@ -18,6 +17,7 @@ import {
 import {Claim} from '../../../../../../main/common/models/claim';
 import {Respondent} from '../../../../../../main/common/models/respondent';
 import {buildCorrespondenceAddress, buildPrimaryAddress} from '../../../../../utils/mockClaim';
+import {TestMessages} from '../../../../../utils/errorMessageTestConstants';
 
 jest.mock('../../../../../../main/modules/oidc');
 jest.mock('../../../../../../main/modules/draft-store');
@@ -69,27 +69,27 @@ describe('Confirm Details page', () => {
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
       mockGetRespondentInformation.mockImplementation(async () => {
-        throw new Error(REDIS_FAILURE);
+        throw new Error(TestMessages.REDIS_FAILURE);
       });
       await request(app)
         .get(CITIZEN_DETAILS_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: REDIS_FAILURE});
+          expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
         });
     });
   });
 
   test('should return http 500 when has error in the post method', async () => {
     mockSaveRespondent.mockImplementation(async () => {
-      throw new Error(REDIS_FAILURE);
+      throw new Error(TestMessages.REDIS_FAILURE);
     });
     await request(app)
       .post(CITIZEN_DETAILS_URL)
       .send(validDataForPost)
       .expect((res) => {
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: REDIS_FAILURE});
+        expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
       });
   });
 

--- a/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
+++ b/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
@@ -6,11 +6,11 @@ import {CITIZEN_RESPONSE_TYPE_URL} from '../../../../../../main/routes/urls';
 import * as draftStoreService from '../../../../../../main/modules/draft-store/draftStoreService';
 import {Claim} from '../../../../../../main/common/models/claim';
 import {Respondent} from '../../../../../../main/common/models/respondent';
+import {REDIS_FAILURE} from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
 
 jest.mock('../../../../../../main/modules/oidc');
 jest.mock('../../../../../../main/modules/draft-store/draftStoreService');
 const mockGetCaseData = draftStoreService.getCaseDataFromStore as jest.Mock;
-
 
 describe('Citizen response type', () => {
   const citizenRoleToken: string = config.get('citizenRoleToken');
@@ -22,30 +22,28 @@ describe('Citizen response type', () => {
   });
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
-      const redisFailureError = 'Redis DraftStore failure.';
       mockGetCaseData.mockImplementation(async () => {
-        throw new Error(redisFailureError);
+        throw new Error(REDIS_FAILURE);
       });
       await request(app)
         .get(CITIZEN_RESPONSE_TYPE_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: redisFailureError});
+          expect(res.body).toEqual({error: REDIS_FAILURE});
         });
     });
   });
 
   test('should return http 500 when has error in the post method', async () => {
-    const redisFailureError = 'Redis DraftStore failure.';
     mockGetCaseData.mockImplementation(async () => {
-      throw new Error(redisFailureError);
+      throw new Error(REDIS_FAILURE);
     });
     await request(app)
       .post(CITIZEN_RESPONSE_TYPE_URL)
       .send('responseType=test')
       .expect((res) => {
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: redisFailureError});
+        expect(res.body).toEqual({error: REDIS_FAILURE});
       });
   });
   describe('on GET', () => {

--- a/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
+++ b/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
@@ -6,7 +6,7 @@ import {CITIZEN_RESPONSE_TYPE_URL} from '../../../../../../main/routes/urls';
 import * as draftStoreService from '../../../../../../main/modules/draft-store/draftStoreService';
 import {Claim} from '../../../../../../main/common/models/claim';
 import {Respondent} from '../../../../../../main/common/models/respondent';
-import {REDIS_FAILURE} from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {TestMessages} from '../../../../../utils/errorMessageTestConstants';
 
 jest.mock('../../../../../../main/modules/oidc');
 jest.mock('../../../../../../main/modules/draft-store/draftStoreService');
@@ -20,32 +20,34 @@ describe('Citizen response type', () => {
       .post('/o/token')
       .reply(200, {id_token: citizenRoleToken});
   });
+
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
       mockGetCaseData.mockImplementation(async () => {
-        throw new Error(REDIS_FAILURE);
+        throw new Error(TestMessages.REDIS_FAILURE);
       });
       await request(app)
         .get(CITIZEN_RESPONSE_TYPE_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: REDIS_FAILURE});
+          expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
         });
     });
   });
 
   test('should return http 500 when has error in the post method', async () => {
     mockGetCaseData.mockImplementation(async () => {
-      throw new Error(REDIS_FAILURE);
+      throw new Error(TestMessages.REDIS_FAILURE);
     });
     await request(app)
       .post(CITIZEN_RESPONSE_TYPE_URL)
       .send('responseType=test')
       .expect((res) => {
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: REDIS_FAILURE});
+        expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
       });
   });
+
   describe('on GET', () => {
     test('should return empty citizen response type page', async () => {
       mockGetCaseData.mockImplementation(async () => new Claim());
@@ -56,6 +58,7 @@ describe('Citizen response type', () => {
           expect(res.text).toContain('How do you respond to the claim?');
         });
     });
+
     test('should return citizen response type page with all information from redis', async () => {
       mockGetCaseData.mockImplementation(async () => {
         const claim = new Claim();
@@ -83,6 +86,7 @@ describe('Citizen response type', () => {
           expect(res.text).toContain('Choose your response');
         });
     });
+
     test('should redirect page when correct input', async () => {
       await request(app)
         .post(CITIZEN_RESPONSE_TYPE_URL)
@@ -91,6 +95,7 @@ describe('Citizen response type', () => {
           expect(res.status).toBe(302);
         });
     });
+
     test('should redirect page when correct input when has information on redis', async () => {
       mockGetCaseData.mockImplementation(async () => {
         const claim = new Claim();
@@ -106,6 +111,7 @@ describe('Citizen response type', () => {
           expect(res.status).toBe(302);
         });
     });
+
     test('should redirect page when correct input when dont have information on redis of respondent1', async () => {
       mockGetCaseData.mockImplementation(async () => undefined);
       await request(app)

--- a/src/test/unit/routes/features/response/financial-details/financialDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/financial-details/financialDetailsController.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../../../../../../main/routes/features/response/financialDetails/financialDetailsController';
 import {Logger} from 'winston';
 import {FINANCIAL_DETAILS_URL} from '../../../../../../main/routes/urls';
+import {mockRedisFailure} from '../../../../../utils/mockDraftStore';
+import {REDIS_FAILURE} from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
 
 const claimIndividualMock = require('./claimIndividualMock.json');
 const claimIndividualMockNoType = require('./claimIndividualMockNoType.json');
@@ -67,23 +69,16 @@ describe('Citizen financial details', () => {
         });
     });
     test('should not match expected string, and log error, if draft store fails to return anything', async () => {
-      mockDraftStore = {
-        set: jest.fn(() => Promise.resolve({data: {}})),
-        get: jest.fn(() => {
-          throw new Error('Redis DraftStore failure.');
-        }),
-      };
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .get(constructResponseUrlWithIdParams('1646768947464020', FINANCIAL_DETAILS_URL))
         .expect((res) => {
           expect(res.status).toBe(200);
           expect(res.text).not.toContain('your company or organisation&#39;s most recent statement of accounts');
-          expect(mockLogger.error).toHaveBeenCalledWith('Redis DraftStore failure.');
+          expect(mockLogger.error).toHaveBeenCalledWith(REDIS_FAILURE);
         });
     });
   });
-
 
   describe('on POST', () => {
     test('should redirect for individual', async () => {
@@ -111,18 +106,12 @@ describe('Citizen financial details', () => {
         });
     });
     test('should not redirect, and log error, if draft store fails to return anything', async () => {
-      mockDraftStore = {
-        set: jest.fn(() => Promise.resolve({data: {}})),
-        get: jest.fn(() => {
-          throw new Error('Redis DraftStore failure.');
-        }),
-      };
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .post(constructResponseUrlWithIdParams('1646768947464020', FINANCIAL_DETAILS_URL))
         .expect((res) => {
           expect(res.status).toBe(200);
-          expect(mockLogger.error).toHaveBeenCalledWith('Redis DraftStore failure.');
+          expect(mockLogger.error).toHaveBeenCalledWith(REDIS_FAILURE);
         });
     });
     test('should be 404 for no caseId in path', async () => {

--- a/src/test/unit/routes/features/response/financial-details/financialDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/financial-details/financialDetailsController.test.ts
@@ -9,7 +9,7 @@ import {
 import {Logger} from 'winston';
 import {FINANCIAL_DETAILS_URL} from '../../../../../../main/routes/urls';
 import {mockRedisFailure} from '../../../../../utils/mockDraftStore';
-import {REDIS_FAILURE} from '../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {TestMessages} from '../../../../../utils/errorMessageTestConstants';
 
 const claimIndividualMock = require('./claimIndividualMock.json');
 const claimIndividualMockNoType = require('./claimIndividualMockNoType.json');
@@ -75,7 +75,7 @@ describe('Citizen financial details', () => {
         .expect((res) => {
           expect(res.status).toBe(200);
           expect(res.text).not.toContain('your company or organisation&#39;s most recent statement of accounts');
-          expect(mockLogger.error).toHaveBeenCalledWith(REDIS_FAILURE);
+          expect(mockLogger.error).toHaveBeenCalledWith(TestMessages.REDIS_FAILURE);
         });
     });
   });
@@ -111,7 +111,7 @@ describe('Citizen financial details', () => {
         .post(constructResponseUrlWithIdParams('1646768947464020', FINANCIAL_DETAILS_URL))
         .expect((res) => {
           expect(res.status).toBe(200);
-          expect(mockLogger.error).toHaveBeenCalledWith(REDIS_FAILURE);
+          expect(mockLogger.error).toHaveBeenCalledWith(TestMessages.REDIS_FAILURE);
         });
     });
     test('should be 404 for no caseId in path', async () => {

--- a/src/test/unit/routes/features/response/statementOfMeans/bankAccounts/bankAccountsController.test.ts
+++ b/src/test/unit/routes/features/response/statementOfMeans/bankAccounts/bankAccountsController.test.ts
@@ -12,7 +12,6 @@ jest.mock('../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../main/modules/draft-store');
 jest.mock('../../../../../../../main/modules/draft-store/draftStoreService');
 
-
 describe('Bank Accounts and Savings', ()=>{
   const citizenRoleToken: string = config.get('citizenRoleToken');
   const idamUrl: string = config.get('idamUrl');

--- a/src/test/unit/routes/features/response/statementOfMeans/debts/debtsController.test.ts
+++ b/src/test/unit/routes/features/response/statementOfMeans/debts/debtsController.test.ts
@@ -27,7 +27,6 @@ jest.mock('../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../main/modules/draft-store/draftStoreService');
 const mockGetCaseData = draftStoreService.getCaseDataFromStore as jest.Mock;
 
-
 describe('Debts', () => {
   const citizenRoleToken: string = config.get('citizenRoleToken');
   const idamUrl: string = config.get('idamUrl');
@@ -36,6 +35,7 @@ describe('Debts', () => {
       .post('/o/token')
       .reply(200, {id_token: citizenRoleToken});
   });
+
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
       mockGetCaseData.mockImplementation(async () => {

--- a/src/test/unit/routes/features/response/statementOfMeans/dependants/betweenSixteenAndNineteenController.test.ts
+++ b/src/test/unit/routes/features/response/statementOfMeans/dependants/betweenSixteenAndNineteenController.test.ts
@@ -8,13 +8,14 @@ import {
   CITIZEN_OTHER_DEPENDANTS_URL,
 } from '../../../../../../../main/routes/urls';
 import {
-  REDIS_ERROR_MESSAGE,
+  REDIS_FAILURE,
   VALID_INTEGER,
   VALID_NUMBER_FOR_PREVIOUS_PAGE,
   VALID_POSITIVE_NUMBER,
 } from '../../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import * as childrenDisabilityService
   from '../../../../../../../main/modules/statementOfMeans/dependants/childrenDisabilityService';
+import {mockCivilClaim, mockRedisFailure} from '../../../../../../utils/mockDraftStore';
 
 jest.mock('../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../main/modules/draft-store');
@@ -22,19 +23,6 @@ jest.mock('../../../../../../../main/modules/statementOfMeans/dependants/childre
 const mockHasDisabledChildren = childrenDisabilityService.hasDisabledChildren as jest.Mock;
 
 const EXPECTED_TEXT = 'Children aged 16 to 19 living with you';
-const mockDraftStore = {
-  set: jest.fn(() => Promise.resolve({})),
-  get: jest.fn(() => Promise.resolve({})),
-};
-
-const mockErrorDraftStore = {
-  set: jest.fn(() => {
-    throw new Error(REDIS_ERROR_MESSAGE);
-  }),
-  get: jest.fn(() => {
-    throw new Error(REDIS_ERROR_MESSAGE);
-  }),
-};
 
 describe('Dependant Teenagers', () => {
   const citizenRoleToken: string = config.get('citizenRoleToken');
@@ -45,7 +33,7 @@ describe('Dependant Teenagers', () => {
       .reply(200, {id_token: citizenRoleToken});
   });
   describe('on GET', () => {
-    app.locals.draftStoreClient = mockDraftStore;
+    app.locals.draftStoreClient = mockCivilClaim;
     test('should return dependent teenagers page', async () => {
       await request(app)
         .get(CITIZEN_DEPENDANTS_EDUCATION_URL)
@@ -55,17 +43,17 @@ describe('Dependant Teenagers', () => {
         });
     });
     test('should return 500 error code when there is an error', async () => {
-      app.locals.draftStoreClient = mockErrorDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .get(CITIZEN_DEPENDANTS_EDUCATION_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
+          expect(res.body).toEqual({error: REDIS_FAILURE});
         });
     });
   });
   describe('on POST', () => {
-    app.locals.draftStoreClient = mockDraftStore;
+    app.locals.draftStoreClient = mockCivilClaim;
     test('should show error when no number is added', async () => {
       await request(app)
         .post(CITIZEN_DEPENDANTS_EDUCATION_URL)
@@ -106,7 +94,7 @@ describe('Dependant Teenagers', () => {
       mockHasDisabledChildren.mockImplementation( () => {
         return false;
       });
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
       await request(app)
         .post(CITIZEN_DEPENDANTS_EDUCATION_URL)
         .send({value: 1, maxValue: 3})
@@ -119,7 +107,7 @@ describe('Dependant Teenagers', () => {
       mockHasDisabledChildren.mockImplementation( () => {
         return true;
       });
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
       await request(app)
         .post(CITIZEN_DEPENDANTS_EDUCATION_URL)
         .send({value: 1, maxValue: 3})
@@ -129,13 +117,13 @@ describe('Dependant Teenagers', () => {
         });
     });
     test('should return 500 code when there is an error', async () => {
-      app.locals.draftStoreClient = mockErrorDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .post(CITIZEN_DEPENDANTS_EDUCATION_URL)
         .send({value: 1, maxValue: 3})
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body).toEqual({error: REDIS_ERROR_MESSAGE});
+          expect(res.body).toEqual({error: REDIS_FAILURE});
         });
     });
   });

--- a/src/test/unit/routes/features/response/statementOfMeans/dependants/childrenDisabilityController.test.ts
+++ b/src/test/unit/routes/features/response/statementOfMeans/dependants/childrenDisabilityController.test.ts
@@ -3,44 +3,30 @@ import {app} from '../../../../../../../main/app';
 import nock from 'nock';
 import config from 'config';
 import {CHILDREN_DISABILITY_URL, CITIZEN_OTHER_DEPENDANTS_URL} from '../../../../../../../main/routes/urls';
-import {VALID_YES_NO_OPTION} from '../../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {
+  REDIS_FAILURE,
+  VALID_YES_NO_OPTION,
+} from '../../../../../../../main/common/form/validationErrors/errorMessageConstants';
 import {Logger} from 'winston';
 import {
   setChildrenDisabilityControllerLogger,
 } from '../../../../../../../main/routes/features/response/statementOfMeans/dependants/childrenDisabilityController';
+import {mockCivilClaim, mockRedisFailure} from '../../../../../../utils/mockDraftStore';
 
-
-const civilClaimResponseMock = require('../civilClaimResponseMock.json');
 const noStatementOfMeansMock = require('../noStatementOfMeansMock.json');
-const civilClaimResponse: string = JSON.stringify(civilClaimResponseMock);
 const noChildrenDisabilityResponse: string = JSON.stringify(noStatementOfMeansMock);
 
-const mockDraftStore = {
-  set: jest.fn(() => Promise.resolve({})),
-  get: jest.fn(() => Promise.resolve(civilClaimResponse)),
-};
 const mockNoChildrenDisabilityDraftStore = {
   set: jest.fn(() => Promise.resolve({})),
   get: jest.fn(() => Promise.resolve(noChildrenDisabilityResponse)),
-};
-const mockErrorDraftStore = {
-  set: jest.fn(() => {
-    throw new Error('Redis DraftStore failure.');
-  }),
-  get: jest.fn(() => {
-    throw new Error('Redis DraftStore failure.');
-  }),
 };
 const mockLogger = {
   error: jest.fn().mockImplementation((message: string) => message),
   info: jest.fn().mockImplementation((message: string) => message),
 } as unknown as Logger;
 
-
 jest.mock('../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../main/modules/draft-store');
-
-const redisFailureError = 'Redis DraftStore failure.';
 
 describe('Children Disability', () => {
   const citizenRoleToken: string = config.get('citizenRoleToken');
@@ -54,25 +40,25 @@ describe('Children Disability', () => {
 
   describe('on Exception', () => {
     test('should return http 500 when has error in the get method', async () => {
-      app.locals.draftStoreClient = mockErrorDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .get(CHILDREN_DISABILITY_URL)
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body.errorMessage).toEqual(redisFailureError);
+          expect(res.body.errorMessage).toEqual(REDIS_FAILURE);
           expect(mockLogger.error).toHaveBeenCalled();
         });
     });
 
 
     test('should return http 500 when has error in the post method', async () => {
-      app.locals.draftStoreClient = mockErrorDraftStore;
+      app.locals.draftStoreClient = mockRedisFailure;
       await request(app)
         .post(CHILDREN_DISABILITY_URL)
         .send('option=no')
         .expect((res) => {
           expect(res.status).toBe(500);
-          expect(res.body.errorMessage).toEqual(redisFailureError);
+          expect(res.body.errorMessage).toEqual(REDIS_FAILURE);
           expect(mockLogger.error).toHaveBeenCalled();
         });
     });
@@ -80,7 +66,7 @@ describe('Children Disability', () => {
 
   describe('on GET', () => {
     test('should return children disability page', async () => {
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
       await request(app)
         .get(CHILDREN_DISABILITY_URL)
         .expect((res) => {
@@ -111,7 +97,7 @@ describe('Children Disability', () => {
         });
     });
     test('should redirect page when "no"', async () => {
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
       await request(app)
         .post(CHILDREN_DISABILITY_URL)
         .send('option=no')
@@ -121,7 +107,7 @@ describe('Children Disability', () => {
         });
     });
     test('should redirect page when "yes"', async () => {
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
       await request(app)
         .post(CHILDREN_DISABILITY_URL)
         .send('option=yes')
@@ -131,7 +117,7 @@ describe('Children Disability', () => {
         });
     });
     test('should return error on incorrect input', async () => {
-      app.locals.draftStoreClient = mockDraftStore;
+      app.locals.draftStoreClient = mockCivilClaim;
       await request(app)
         .post(CHILDREN_DISABILITY_URL)
         .send('')
@@ -141,5 +127,4 @@ describe('Children Disability', () => {
         });
     });
   });
-
 });

--- a/src/test/unit/routes/features/response/statementOfMeans/otherDependants/otherDependantsController.test.ts
+++ b/src/test/unit/routes/features/response/statementOfMeans/otherDependants/otherDependantsController.test.ts
@@ -12,33 +12,19 @@ import {
   DETAILS_REQUIRED,
   VALID_NUMBER_OF_PEOPLE,
 } from '../../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {TestMessages} from '../../../../../../../test/utils/errorMessageTestConstants';
+import {mockCivilClaim, mockCivilClaimOptionNo, mockRedisFailure} from '../../../../../../utils/mockDraftStore';
 
-import { TestMessages } from '../../../../../../../test/utils/errorMessageTestConstants';
-
-const civilClaimResponseMock = require('../../../../../../utils/mocks/civilClaimResponseMock.json');
-const noDisabilityMock = require('../../../../../../utils/mocks/civilClaimResponseOptionNoMock.json');
 const withoutOtherDependentJson = require('./withoutOtherDependantsMock.json');
-const civilClaimResponse: string = JSON.stringify(civilClaimResponseMock);
-const civilClaimResponseWithoutDisability: string = JSON.stringify(noDisabilityMock);
 const civilClaimResponseWithoutOtherDependent: string = JSON.stringify(withoutOtherDependentJson);
-const mockRedisException = {
-  set: jest.fn(() => Promise.resolve({})),
-  get: jest.fn(() => Promise.resolve(civilClaimResponse)),
-};
-const mockNoDisabilityDraftStore = {
-  set: jest.fn(() => Promise.resolve({})),
-  get: jest.fn(() => Promise.resolve(civilClaimResponseWithoutDisability)),
-};
+
 const mockWithoutOtherDependents = {
   set: jest.fn(() => Promise.resolve({})),
   get: jest.fn(() => Promise.resolve(civilClaimResponseWithoutOtherDependent)),
 };
-const mockRedisFailure = {
-  set: jest.fn(() => Promise.resolve({})),
-  get: jest.fn(() => {throw new Error(TestMessages.REDIS_FAILURE);})};
+
 jest.mock('../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../main/modules/draft-store');
-
 
 describe('Other Dependants', () => {
   const citizenRoleToken: string = config.get('citizenRoleToken');
@@ -46,165 +32,164 @@ describe('Other Dependants', () => {
   beforeEach(() => {
     nock(idamUrl)
       .post('/o/token')
-      .reply(200, { id_token: citizenRoleToken });
-  });
-});
-
-describe('on GET', () => {
-  test('should return other dependants page', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .get(CITIZEN_OTHER_DEPENDANTS_URL)
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain('Do you support anyone else financially?');
-      });
+      .reply(200, {id_token: citizenRoleToken});
   });
 
-  test('should show "Number of people and Give details" section when "yes"', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .get(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send('option=yes')
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain('Number of people');
-        expect(res.text).toContain('Give details');
-      });
+  describe('on GET', () => {
+    test('should return other dependants page', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .get(CITIZEN_OTHER_DEPENDANTS_URL)
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain('Do you support anyone else financially?');
+        });
+    });
+
+    test('should show "Number of people and Give details" section when "yes"', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .get(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send('option=yes')
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain('Number of people');
+          expect(res.text).toContain('Give details');
+        });
+    });
+
+    test('should return error when Cannot read property \'numberOfPeople\' and \'details\' of undefined', async () => {
+      app.locals.draftStoreClient = mockRedisFailure;
+      await request(app)
+        .get(CITIZEN_OTHER_DEPENDANTS_URL)
+        .expect((res) => {
+          expect(res.status).toBe(500);
+          expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
+        });
+    });
+
+    test('should return empty OtherDependants object', async () => {
+      app.locals.draftStoreClient = mockWithoutOtherDependents;
+      await request(app)
+        .get(CITIZEN_OTHER_DEPENDANTS_URL)
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain('Do you support anyone else financially?');
+        });
+    });
   });
 
-  test('should return error when Cannot read property \'numberOfPeople\' and \'details\' of undefined', async () => {
-    app.locals.draftStoreClient = mockRedisFailure;
-    await request(app)
-      .get(CITIZEN_OTHER_DEPENDANTS_URL)
-      .expect((res) => {
-        expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
-      });
-  });
+  describe('on POST', () => {
+    test('should return error when radio box is not selected', async () => {
+      app.locals.draftStoreClient = mockCivilClaimOptionNo;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send('')
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(VALID_YES_NO_OPTION);
+        });
+    });
 
-  test('should return empty OtherDependants object', async () => {
-    app.locals.draftStoreClient = mockWithoutOtherDependents;
-    await request(app)
-      .get(CITIZEN_OTHER_DEPENDANTS_URL)
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain('Do you support anyone else financially?');
-      });
-  });
-});
+    test('should redirect when "no" is selected', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'no', numberOfPeople: '', details: ''})
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_EMPLOYMENT_URL);
+        });
+    });
 
-describe('on POST', () => {
-  test('should return error when radio box is not selected', async () => {
-    app.locals.draftStoreClient = mockNoDisabilityDraftStore;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send('')
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(VALID_YES_NO_OPTION);
-      });
-  });
+    test('should redirect when "yes" is selected and number of people and details are valid', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'no', numberOfPeople: '1', details: 'Test details'})
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_EMPLOYMENT_URL);
+        });
+    });
 
-  test('should redirect when "no" is selected', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'no', numberOfPeople: '', details: '' })
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_EMPLOYMENT_URL);
-      });
-  });
+    test('should return error when number of people is undefined', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'yes', numberOfPeople: '', details: ''})
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(NUMBER_OF_PEOPLE_REQUIRED);
+        });
+    });
 
-  test('should redirect when "yes" is selected and number of people and details are valid', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'no', numberOfPeople: '1', details: 'Test details' })
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_EMPLOYMENT_URL);
-      });
-  });
+    test('should return error when number of people is 0', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'yes', numberOfPeople: '0', details: ''})
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(VALID_NUMBER_OF_PEOPLE);
+        });
+    });
 
-  test('should return error when number of people is undefined', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'yes', numberOfPeople: '', details: '' })
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(NUMBER_OF_PEOPLE_REQUIRED);
-      });
-  });
+    test('should return error when number of people is valid details is undefined', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'yes', numberOfPeople: '1', details: ''})
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(DETAILS_REQUIRED);
+        });
+    });
 
-  test('should return error when number of people is 0', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'yes', numberOfPeople: '0', details: '' })
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(VALID_NUMBER_OF_PEOPLE);
-      });
-  });
+    test('should return error when number of people and details are undefined', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'yes', numberOfPeople: '', details: ''})
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(NUMBER_OF_PEOPLE_REQUIRED);
+          expect(res.text).toContain(DETAILS_REQUIRED);
+        });
+    });
 
-  test('should return error when number of people is valid details is undefined', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'yes', numberOfPeople: '1', details: '' })
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(DETAILS_REQUIRED);
-      });
-  });
+    test('should return error when number of people is 0 details is undefined', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'yes', numberOfPeople: '0', details: ''})
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(VALID_NUMBER_OF_PEOPLE);
+          expect(res.text).toContain(DETAILS_REQUIRED);
+        });
+    });
 
-  test('should return error when number of people and details are undefined', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'yes', numberOfPeople: '', details: '' })
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(NUMBER_OF_PEOPLE_REQUIRED);
-        expect(res.text).toContain(DETAILS_REQUIRED);
-      });
-  });
+    test('should save when we dont have information on redis', async () => {
+      app.locals.draftStoreClient = mockWithoutOtherDependents;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'no', numberOfPeople: '1', details: 'Test details'})
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_EMPLOYMENT_URL);
+        });
+    });
 
-  test('should return error when number of people is 0 details is undefined', async () => {
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'yes', numberOfPeople: '0', details: '' })
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(VALID_NUMBER_OF_PEOPLE);
-        expect(res.text).toContain(DETAILS_REQUIRED);
-      });
-  });
-  test('should save when we dont have information on redis', async () => {
-    app.locals.draftStoreClient = mockWithoutOtherDependents;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'no', numberOfPeople: '1', details: 'Test details' })
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_EMPLOYMENT_URL);
-      });
-  });
-  test('should throw an error when call redis', async () => {
-    const mockRedisException = {
-      set: jest.fn(() => Promise.resolve({})),
-      get: jest.fn(() => {throw new Error(TestMessages.REDIS_FAILURE);})};
-    app.locals.draftStoreClient = mockRedisException;
-    await request(app)
-      .post(CITIZEN_OTHER_DEPENDANTS_URL)
-      .send({ option: 'no', numberOfPeople: '1', details: 'Test details' })
-      .expect((res) => {
-        expect(res.status).toBe(500);
-        expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
-      });
+    test('should throw an error when call redis', async () => {
+      app.locals.draftStoreClient = mockRedisFailure;
+      await request(app)
+        .post(CITIZEN_OTHER_DEPENDANTS_URL)
+        .send({option: 'no', numberOfPeople: '1', details: 'Test details'})
+        .expect((res) => {
+          expect(res.status).toBe(500);
+          expect(res.body).toEqual({error: TestMessages.REDIS_FAILURE});
+        });
+    });
   });
 });

--- a/src/test/unit/routes/features/response/statementOfMeans/partner/partnerPensionController.test.ts
+++ b/src/test/unit/routes/features/response/statementOfMeans/partner/partnerPensionController.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import { app } from '../../../../../../../main/app';
+import {app} from '../../../../../../../main/app';
 import nock from 'nock';
 import config from 'config';
 import {
@@ -7,9 +7,15 @@ import {
   CITIZEN_PARTNER_DISABILITY_URL,
   CITIZEN_PARTNER_PENSION_URL,
 } from '../../../../../../../main/routes/urls';
-import { VALID_YES_NO_OPTION } from '../../../../../../../main/common/form/validationErrors/errorMessageConstants';
-import { TestMessages } from '../../../../../../utils/errorMessageTestConstants';
-import { mockCivilClaim, mockCivilClaimUndefined, mockNoStatementOfMeans, mockCivilClaimOptionNo, mockRedisFailure } from '../../../../../../utils/mockDraftStore';
+import {VALID_YES_NO_OPTION} from '../../../../../../../main/common/form/validationErrors/errorMessageConstants';
+import {TestMessages} from '../../../../../../utils/errorMessageTestConstants';
+import {
+  mockCivilClaim,
+  mockCivilClaimUndefined,
+  mockNoStatementOfMeans,
+  mockCivilClaimOptionNo,
+  mockRedisFailure,
+} from '../../../../../../utils/mockDraftStore';
 
 jest.mock('../../../../../../../main/modules/oidc');
 jest.mock('../../../../../../../main/modules/draft-store');
@@ -20,117 +26,127 @@ describe('Partner Pension', () => {
   beforeEach(() => {
     nock(idamUrl)
       .post('/o/token')
-      .reply(200, { id_token: citizenRoleToken });
+      .reply(200, {id_token: citizenRoleToken});
   });
-});
 
-describe('on GET', () => {
-  test('should return citizen partner pension page', async () => {
-    app.locals.draftStoreClient = mockCivilClaim;
-    await request(app)
-      .get(CITIZEN_PARTNER_PENSION_URL)
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(TestMessages.DOES_YOUR_PARTNER_RECEIVE_PENSION);
-      });
+  describe('on GET', () => {
+    test('should return citizen partner pension page', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .get(CITIZEN_PARTNER_PENSION_URL)
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(TestMessages.DOES_YOUR_PARTNER_RECEIVE_PENSION);
+        });
+    });
+
+    test('should show partner pension page when haven´t statementOfMeans', async () => {
+      app.locals.draftStoreClient = mockNoStatementOfMeans;
+      await request(app)
+        .get(CITIZEN_PARTNER_PENSION_URL)
+        .send()
+        .expect((res) => {
+          expect(res.status).toBe(200);
+        });
+    });
+
+    test('should return http 500 when has error', async () => {
+      app.locals.draftStoreClient = mockRedisFailure;
+      await request(app)
+        .get(CITIZEN_PARTNER_PENSION_URL)
+        .expect((res) => {
+          expect(res.status).toBe(500);
+          expect(res.body).toMatchObject({error: TestMessages.REDIS_FAILURE});
+        });
+    });
   });
-  test('should show partner pension page when haven´t statementOfMeans', async () => {
-    app.locals.draftStoreClient = mockNoStatementOfMeans;
-    await request(app)
-      .get(CITIZEN_PARTNER_PENSION_URL)
-      .send()
-      .expect((res) => {
-        expect(res.status).toBe(200);
-      });
-  });
-  test('should return http 500 when has error', async () => {
-    app.locals.draftStoreClient = mockRedisFailure;
-    await request(app)
-      .get(CITIZEN_PARTNER_PENSION_URL)
-      .expect((res) => {
-        expect(res.status).toBe(500);
-        expect(res.body).toMatchObject({ error: TestMessages.REDIS_FAILURE });
-      });
-  });
-});
-describe('on POST', () => {
-  test('should create a new claim if redis gives undefined', async () => {
-    app.locals.draftStoreClient = mockCivilClaimUndefined;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=no')
-      .expect((res) => {
-        expect(res.status).toBe(302);
-      });
-  });
-  test('should redirect page when "no" and defendant disabled = yes', async () => {
-    app.locals.draftStoreClient = mockCivilClaim;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=no')
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_PARTNER_DISABILITY_URL);
-      });
-  });
-  test('should redirect page when "no" and defendant disabled = no', async () => {
-    app.locals.draftStoreClient = mockCivilClaimOptionNo;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=no')
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_DEPENDANTS_URL);
-      });
-  });
-  test('should redirect page when "yes" and defendant disabled = no', async () => {
-    app.locals.draftStoreClient = mockCivilClaimOptionNo;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=yes')
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_DEPENDANTS_URL);
-      });
-  });
-  test('should redirect page when "yes" and defendant disabled = yes', async () => {
-    app.locals.draftStoreClient = mockCivilClaim;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=yes')
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_PARTNER_DISABILITY_URL);
-      });
-  });
-  test('should return error on incorrect input', async () => {
-    app.locals.draftStoreClient = mockCivilClaim;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('')
-      .expect((res) => {
-        expect(res.status).toBe(200);
-        expect(res.text).toContain(VALID_YES_NO_OPTION);
-      });
-  });
-  test('should redirect partner disability page when "no" and haven´t statementOfMeans', async () => {
-    app.locals.draftStoreClient = mockNoStatementOfMeans;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=no')
-      .expect((res) => {
-        expect(res.status).toBe(302);
-        expect(res.header.location).toEqual(CITIZEN_PARTNER_DISABILITY_URL);
-      });
-  });
-  test('should return http 500 when has error', async () => {
-    app.locals.draftStoreClient = mockRedisFailure;
-    await request(app)
-      .post(CITIZEN_PARTNER_PENSION_URL)
-      .send('option=no')
-      .expect((res) => {
-        expect(res.status).toBe(500);
-        expect(res.body).toMatchObject({ error: TestMessages.REDIS_FAILURE });
-      });
+
+  describe('on POST', () => {
+    test('should create a new claim if redis gives undefined', async () => {
+      app.locals.draftStoreClient = mockCivilClaimUndefined;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=no')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+        });
+    });
+
+    test('should redirect page when "no" and defendant disabled = yes', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=no')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_PARTNER_DISABILITY_URL);
+        });
+    });
+
+    test('should redirect page when "no" and defendant disabled = no', async () => {
+      app.locals.draftStoreClient = mockCivilClaimOptionNo;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=no')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_DEPENDANTS_URL);
+        });
+    });
+
+    test('should redirect page when "yes" and defendant disabled = no', async () => {
+      app.locals.draftStoreClient = mockCivilClaimOptionNo;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=yes')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_DEPENDANTS_URL);
+        });
+    });
+
+    test('should redirect page when "yes" and defendant disabled = yes', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=yes')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_PARTNER_DISABILITY_URL);
+        });
+    });
+
+    test('should return error on incorrect input', async () => {
+      app.locals.draftStoreClient = mockCivilClaim;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('')
+        .expect((res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toContain(VALID_YES_NO_OPTION);
+        });
+    });
+
+    test('should redirect partner disability page when "no" and haven´t statementOfMeans', async () => {
+      app.locals.draftStoreClient = mockNoStatementOfMeans;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=no')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CITIZEN_PARTNER_DISABILITY_URL);
+        });
+    });
+
+    test('should return http 500 when has error', async () => {
+      app.locals.draftStoreClient = mockRedisFailure;
+      await request(app)
+        .post(CITIZEN_PARTNER_PENSION_URL)
+        .send('option=no')
+        .expect((res) => {
+          expect(res.status).toBe(500);
+          expect(res.body).toMatchObject({error: TestMessages.REDIS_FAILURE});
+        });
+    });
   });
 });

--- a/src/test/unit/sample.ts
+++ b/src/test/unit/sample.ts
@@ -1,4 +1,0 @@
-describe('Example test to satisfy jest (to be removed from your app)', () => {
-  test('to be removed from your app', async () => { // eslint-disable-line @typescript-eslint/no-empty-function
-  });
-});


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CIV-2041


### Change description ###
Refactor tests to use mocks from the `mockDraftStore` instead of defining duplicates in files
Refactor tests to use `TestMessages enum`
No new code added, only refactored and indented appropriately

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
