### PR TITLE
bugFix/CIV-2460/Prevent displaying individual defendant details with errors

### DIFF
--- a/src/main/routes/features/response/citizenDetails/citizenDetailsController.ts
+++ b/src/main/routes/features/response/citizenDetails/citizenDetailsController.ts
@@ -29,7 +29,8 @@ const getViewpathWithType = (type: CounterpartyType) => {
 
 function renderPageWithError(res: express.Response, citizenAddress: CitizenAddress, citizenCorrespondenceAddress: CitizenCorrespondenceAddress, errorList: Form, req: express.Request, respondent: Respondent, contactPerson: string): void {
   const partyName = respondent?.partyName;
-  const viewPath = getViewpathWithType(respondent?.type);
+  const type = respondent?.type;
+  const viewPath = getViewpathWithType(type);
   res.render(viewPath, {
     citizenFullName: citizenFullName,
     citizenAddress: citizenAddress,
@@ -44,6 +45,7 @@ function renderPageWithError(res: express.Response, citizenAddress: CitizenAddre
     postToThisAddress: req.body.postToThisAddress,
     partyName: partyName,
     contactPerson: contactPerson,
+    type:type,
   });
 }
 

--- a/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
+++ b/src/test/unit/routes/features/response/citizenDetails/citizenDetailsController.test.ts
@@ -429,6 +429,64 @@ describe('Confirm Details page', () => {
       });
   });
 
+  test('POST/Citizen details - should display organisation details and return errors when postToThisAddress is set to YES', async () => {
+    mockGetRespondentInformation.mockImplementation(async () => {
+      return buildClaimOfRespondentOrganisation();
+    });
+    await request(app)
+      .post(CITIZEN_DETAILS_URL)
+      .send({
+        primaryAddressLine1: '',
+        primaryAddressLine2: '',
+        primaryAddressLine3: '',
+        primaryCity: '',
+        primaryPostCode: '',
+        postToThisAddress: 'yes',
+        correspondenceAddressLine1: '',
+        correspondenceAddressLine2: '',
+        correspondenceAddressLine3: '',
+        correspondenceCity: '',
+        correspondencePostCode: '',
+      })
+      .expect((res) => {
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(VALID_CORRESPONDENCE_ADDRESS_LINE_1);
+        expect(res.text).toContain(VALID_CORRESPONDENCE_CITY);
+        expect(res.text).toContain(VALID_CORRESPONDENCE_POSTCODE);
+        expect(res.text).toContain('Confirm your details');
+        expect(res.text).toContain('Organisation name');
+      });
+  });
+
+  test('POST/Citizen details - should display company details and return errors when postToThisAddress is set to YES', async () => {
+    mockGetRespondentInformation.mockImplementation(async () => {
+      return buildClaimOfRespondentCompany();
+    });
+    await request(app)
+      .post(CITIZEN_DETAILS_URL)
+      .send({
+        primaryAddressLine1: '',
+        primaryAddressLine2: '',
+        primaryAddressLine3: '',
+        primaryCity: '',
+        primaryPostCode: '',
+        postToThisAddress: 'yes',
+        correspondenceAddressLine1: '',
+        correspondenceAddressLine2: '',
+        correspondenceAddressLine3: '',
+        correspondenceCity: '',
+        correspondencePostCode: '',
+      })
+      .expect((res) => {
+        expect(res.status).toBe(200);
+        expect(res.text).toContain(VALID_CORRESPONDENCE_ADDRESS_LINE_1);
+        expect(res.text).toContain(VALID_CORRESPONDENCE_CITY);
+        expect(res.text).toContain(VALID_CORRESPONDENCE_POSTCODE);
+        expect(res.text).toContain('Confirm your details');
+        expect(res.text).toContain('Company name');
+      });
+  });
+
   test('get/Citizen details - should return test variable when there is no data on redis and civil-service', async () => {
     await request(app)
       .get('/case/1111/response/your-details')


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link ###
https://tools.hmcts.net/jira/browse/CIV-2460



### Change description ###
Display organisation/company defendant details when there is an error message on page instead of individual defendant details. 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
