### PR TITLE
Switch from Wiremock instance to actual legacy draft store instance

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,7 +25,7 @@ services:
       key:
       tls: false
     legacy:
-      url: 'http://localhost:8765'
+      url: 'http://localhost:8800'
       s2s:
         microserviceName: 'cmc'
         primarySecret: 'not-a-real-primary-secret'


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/CIV-3175

### Change description ###

Switch from Wiremock instance to actual legacy draft store local instance, which uses Docker image

**IMPORTANT:** Can only be merged after https://github.com/hmcts/civil-sdk/pull/44 is merged

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
