### PR TITLE
fix redis - point it to ccd-network

### DIFF
--- a/compose/draft-store.yml
+++ b/compose/draft-store.yml
@@ -7,6 +7,14 @@ services:
     command: redis-server --save 20 1 --loglevel warning
     volumes:
       - cache:/data
+    networks:
+      - ccd-network
+
+networks:
+  ccd-network:
+    external:
+      name: ccd-network
 volumes:
   cache:
     driver: local
+


### PR DESCRIPTION



### JIRA link ###
no story for this ;p


### Change description ###

So that our environment does not break and we don't have extra default bridge created  by redis container deploy, we change redis yaml to point to existing ccd-network

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
