### PR TITLE
CIV-5450 | remove || new Claim()

### DIFF
--- a/src/main/routes/features/response/citizenPhoneNumber/citizenPhoneController.ts
+++ b/src/main/routes/features/response/citizenPhoneNumber/citizenPhoneController.ts
@@ -33,7 +33,7 @@ citizenPhoneController.post(CITIZEN_PHONE_NUMBER_URL,
       if (citizenTelephoneNumberForm.hasErrors()) {
         renderView(citizenTelephoneNumberForm, res);
       } else {
-        const claim = await getCaseDataFromStore(req.params.id) || new Claim();
+        const claim = await getCaseDataFromStore(req.params.id);
         if (claim.respondent1) {
           claim.respondent1.partyPhone = model.telephoneNumber;
         } else {

--- a/src/main/routes/features/response/responseType/citizenResponseTypeController.ts
+++ b/src/main/routes/features/response/responseType/citizenResponseTypeController.ts
@@ -43,7 +43,7 @@ citizenResponseTypeController.post(CITIZEN_RESPONSE_TYPE_URL,
       if (formResponseType.hasErrors()) {
         renderView(formResponseType, res);
       } else {
-        const claim = await getCaseDataFromStore(req.params.id) || new Claim();
+        const claim = await getCaseDataFromStore(req.params.id);
         if (claim.respondent1) {
           claim.respondent1.responseType = formResponseType.model.responseType;
         } else {

--- a/src/main/services/features/claim/yourDetails/defendantDetailsService.ts
+++ b/src/main/services/features/claim/yourDetails/defendantDetailsService.ts
@@ -1,4 +1,3 @@
-import {Claim} from '../../../../common/models/claim';
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../modules/draft-store/draftStoreService';
 import {Party} from '../../../../common/models/party';
 import {Address} from '../../../../common/form/models/address';
@@ -26,7 +25,7 @@ const getDefendantInformation = async (claimId: string): Promise<Party> => {
  * @return Promise<void>
  * **/
 const saveDefendant = async (claimId: string, propertyName?: string, propertyValue?: any, saveObject?: boolean) => {
-  const claim = await getCaseDataFromStore(claimId) || new Claim();
+  const claim = await getCaseDataFromStore(claimId);
   if (!claim.respondent1) {
     claim.respondent1 = new Party();
   }

--- a/src/main/services/features/response/statementOfMeans/dependants/childrenDisabilityService.ts
+++ b/src/main/services/features/response/statementOfMeans/dependants/childrenDisabilityService.ts
@@ -46,7 +46,7 @@ export const getChildrenDisability = async (claimId: string): Promise<GenericYes
 
 export const saveChildrenDisability = async (claimId: string, childrenDisability: GenericYesNo) => {
   try {
-    const case_data = await getCaseDataFromStore(claimId) || new Claim();
+    const case_data = await getCaseDataFromStore(claimId);
     if (case_data.statementOfMeans) {
       case_data.statementOfMeans.childrenDisability = childrenDisability;
     } else {

--- a/src/main/services/features/response/statementOfMeans/disabilityService.ts
+++ b/src/main/services/features/response/statementOfMeans/disabilityService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../common/models/claim';
 import {GenericForm} from '../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../common/form/models/genericYesNo';
 
@@ -26,7 +25,7 @@ export class DisabilityService {
 
   public async saveDisability(claimId: string, disability: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.disability = disability.model;
       } else {

--- a/src/main/services/features/response/statementOfMeans/employment/selfEmployed/onTaxPaymentsService.ts
+++ b/src/main/services/features/response/statementOfMeans/employment/selfEmployed/onTaxPaymentsService.ts
@@ -46,7 +46,7 @@ const saveTaxPaymentsData = async (claimId: string, form: GenericForm<OnTaxPayme
 };
 
 const getClaim = async (claimId: string): Promise<Claim> => {
-  const claim = await getCaseDataFromStore(claimId) || new Claim();
+  const claim = await getCaseDataFromStore(claimId);
   if (!claim.statementOfMeans) {
     claim.statementOfMeans = new StatementOfMeans();
   }

--- a/src/main/services/features/response/statementOfMeans/employment/selfEmployed/selfEmployedAsService.ts
+++ b/src/main/services/features/response/statementOfMeans/employment/selfEmployed/selfEmployedAsService.ts
@@ -35,7 +35,7 @@ const saveSelfEmployedAsData = async (claimId: string, form: GenericForm<SelfEmp
 };
 
 const getClaim = async (claimId: string): Promise<Claim> => {
-  const claim = await getCaseDataFromStore(claimId) || new Claim();
+  const claim = await getCaseDataFromStore(claimId);
   if (!claim.statementOfMeans) {
     claim.statementOfMeans = new StatementOfMeans();
   }

--- a/src/main/services/features/response/statementOfMeans/partner/cohabitingService.ts
+++ b/src/main/services/features/response/statementOfMeans/partner/cohabitingService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../../common/models/claim';
 import {GenericForm} from '../../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../../common/form/models/genericYesNo';
 
@@ -23,7 +22,7 @@ export class CohabitingService {
 
   public async saveCohabiting(claimId: string, cohabiting: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.cohabiting = cohabiting.model;
       } else {

--- a/src/main/services/features/response/statementOfMeans/partner/partnerAgeService.ts
+++ b/src/main/services/features/response/statementOfMeans/partner/partnerAgeService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../../common/models/claim';
 import {GenericForm} from '../../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../../common/form/models/genericYesNo';
 
@@ -23,7 +22,7 @@ export class PartnerAgeService {
 
   public async savePartnerAge(claimId: string, partner: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.partnerAge = partner.model;
       } else {

--- a/src/main/services/features/response/statementOfMeans/partner/partnerDisabilityService.ts
+++ b/src/main/services/features/response/statementOfMeans/partner/partnerDisabilityService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../../common/models/claim';
 import {GenericForm} from '../../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../../common/form/models/genericYesNo';
 
@@ -26,7 +25,7 @@ export class PartnerDisabilityService {
 
   public async savePartnerDisability(claimId: string, partnerDisability: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.partnerDisability = partnerDisability.model;
       } else {

--- a/src/main/services/features/response/statementOfMeans/partner/partnerPensionService.ts
+++ b/src/main/services/features/response/statementOfMeans/partner/partnerPensionService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../../common/models/claim';
 import {GenericForm} from '../../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../../common/form/models/genericYesNo';
 
@@ -26,7 +25,7 @@ export class PartnerPensionService {
 
   public async savePartnerPension(claimId: string, partnerPension: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.partnerPension = partnerPension.model;
       } else {

--- a/src/main/services/features/response/statementOfMeans/partner/partnerSevereDisabilityService.ts
+++ b/src/main/services/features/response/statementOfMeans/partner/partnerSevereDisabilityService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../../common/models/claim';
 import {GenericForm} from '../../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../../common/form/models/genericYesNo';
 
@@ -26,7 +25,7 @@ export class PartnerSevereDisabilityService {
 
   public async savePartnerSevereDisability(claimId: string, partnerSevereDisability: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.partnerSevereDisability = partnerSevereDisability.model;
       } else {

--- a/src/main/services/features/response/statementOfMeans/severeDisabilityService.ts
+++ b/src/main/services/features/response/statementOfMeans/severeDisabilityService.ts
@@ -1,6 +1,5 @@
 import {getCaseDataFromStore, saveDraftClaim} from '../../../../modules/draft-store/draftStoreService';
 import {StatementOfMeans} from '../../../../common/models/statementOfMeans';
-import {Claim} from '../../../../common/models/claim';
 import {GenericForm} from '../../../../common/form/models/genericForm';
 import {GenericYesNo} from '../../../../common/form/models/genericYesNo';
 
@@ -25,7 +24,7 @@ export class SevereDisabilityService {
 
   public async saveSevereDisability(claimId: string, severeDisability: GenericForm<GenericYesNo>) {
     try {
-      const case_data = await getCaseDataFromStore(claimId) || new Claim();
+      const case_data = await getCaseDataFromStore(claimId);
       if (case_data?.statementOfMeans) {
         case_data.statementOfMeans.severeDisability = severeDisability.model;
       } else {

--- a/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
+++ b/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
@@ -118,6 +118,19 @@ describe('Citizen response type', () => {
         });
     });
 
+    it('should redirect page when correct input when dont have information on redis of respondent1', async () => {
+      mockGetCaseData.mockImplementation(async () => {
+        return new Claim();
+      });
+      await request(app)
+        .post(CITIZEN_RESPONSE_TYPE_URL)
+        .send('responseType=test')
+        .expect((res) => {
+          expect(res.status).toBe(302);
+          expect(res.header.location).toEqual(CLAIM_TASK_LIST_URL);
+        });
+    });
+
     it('should redirect page when user selects I admit part of the claim ', async () => {
       mockGetCaseData.mockImplementation(async () => {
         const claim = new Claim();

--- a/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
+++ b/src/test/unit/routes/features/response/citizenResponseType/citizenResponseTypeController.test.ts
@@ -118,17 +118,6 @@ describe('Citizen response type', () => {
         });
     });
 
-    it('should redirect page when correct input when dont have information on redis of respondent1', async () => {
-      mockGetCaseData.mockImplementation(async () => undefined);
-      await request(app)
-        .post(CITIZEN_RESPONSE_TYPE_URL)
-        .send('responseType=test')
-        .expect((res) => {
-          expect(res.status).toBe(302);
-          expect(res.header.location).toEqual(CLAIM_TASK_LIST_URL);
-        });
-    });
-
     it('should redirect page when user selects I admit part of the claim ', async () => {
       mockGetCaseData.mockImplementation(async () => {
         const claim = new Claim();

--- a/src/test/unit/services/features/claim/yourDetails/defendantDetailsService.test.ts
+++ b/src/test/unit/services/features/claim/yourDetails/defendantDetailsService.test.ts
@@ -57,6 +57,18 @@ describe('Defendant details service', () => {
       expect(spySaveDraftClaim).toBeCalledWith(CLAIM_ID, expectedData);
     });
 
+    it('should save a defendant type when is undefined in redis', async () => {
+      const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
+      const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');
+      mockGetCaseData.mockImplementation(async () => {
+        return new Claim();
+      });
+
+      await saveDefendant(CLAIM_ID, 'type', PartyType.INDIVIDUAL);
+      expect(spyGetCaseDataFromStore).toBeCalled();
+      expect(spySaveDraftClaim).toBeCalled();
+    });
+
     it('should update defendant when in redis', async () => {
       const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
       const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');

--- a/src/test/unit/services/features/claim/yourDetails/defendantDetailsService.test.ts
+++ b/src/test/unit/services/features/claim/yourDetails/defendantDetailsService.test.ts
@@ -57,18 +57,6 @@ describe('Defendant details service', () => {
       expect(spySaveDraftClaim).toBeCalledWith(CLAIM_ID, expectedData);
     });
 
-    it('should save a defendant type when is undefined in redis', async () => {
-      const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
-      const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');
-      mockGetCaseData.mockImplementation(async () => {
-        return undefined;
-      });
-
-      await saveDefendant(CLAIM_ID, 'type', PartyType.INDIVIDUAL);
-      expect(spyGetCaseDataFromStore).toBeCalled();
-      expect(spySaveDraftClaim).toBeCalled();
-    });
-
     it('should update defendant when in redis', async () => {
       const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
       const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');

--- a/src/test/unit/services/features/response/statementOfMeans/dependants/childrenDisabilityService.test.ts
+++ b/src/test/unit/services/features/response/statementOfMeans/dependants/childrenDisabilityService.test.ts
@@ -145,20 +145,6 @@ describe('Children Disability service', () => {
       expect(childrenDisability).toEqual(mockClaim?.statementOfMeans?.childrenDisability);
     });
 
-    it('should save childrenDisability when nothing in Redis draft store', async () => {
-      //Given
-      mockGetCaseDataFromDraftStore.mockImplementation(async () => {
-        return undefined;
-      });
-      const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
-      const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');
-      //When
-      await saveChildrenDisability('claimId', new GenericYesNo());
-      //Then
-      expect(spyGetCaseDataFromStore).toBeCalled();
-      expect(spySaveDraftClaim).toBeCalled();
-    });
-
     it('should save childrenDisability when case_data, but no statementOfMeans, in Redis draft store', async () => {
       //Given
       mockGetCaseDataFromDraftStore.mockImplementation(async () => {

--- a/src/test/unit/services/features/response/statementOfMeans/dependants/childrenDisabilityService.test.ts
+++ b/src/test/unit/services/features/response/statementOfMeans/dependants/childrenDisabilityService.test.ts
@@ -15,6 +15,7 @@ import {
 import {GenericForm} from '../../../../../../../main/common/form/models/genericForm';
 import {mockClaim} from '../../../../../../utils/mockClaim';
 import {GenericYesNo} from '../../../../../../../main/common/form/models/genericYesNo';
+import {Claim} from '../../../../../../../main/common/models/claim';
 
 const civilClaimResponseMock = require('../civilClaimResponseMock.json');
 const civilClaimResponse: string = JSON.stringify(civilClaimResponseMock);
@@ -149,6 +150,20 @@ describe('Children Disability service', () => {
       //Given
       mockGetCaseDataFromDraftStore.mockImplementation(async () => {
         return {case_data: {}};
+      });
+      const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
+      const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');
+      //When
+      await saveChildrenDisability('claimId', new GenericYesNo());
+      //Then
+      expect(spyGetCaseDataFromStore).toBeCalled();
+      expect(spySaveDraftClaim).toBeCalled();
+    });
+
+    it('should save childrenDisability when nothing in Redis draft store', async () => {
+      //Given
+      mockGetCaseDataFromDraftStore.mockImplementation(async () => {
+        return new Claim();
       });
       const spyGetCaseDataFromStore = jest.spyOn(draftStoreService, 'getCaseDataFromStore');
       const spySaveDraftClaim = jest.spyOn(draftStoreService, 'saveDraftClaim');

--- a/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployed/onTaxPaymentsService.test.ts
+++ b/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployed/onTaxPaymentsService.test.ts
@@ -80,6 +80,18 @@ describe('On Tax Payments Service', () => {
     });
   });
   describe('saveTaxPaymentsData', () => {
+    it('should save tax payment data successfully when claim does not exist', async () => {
+      //Given
+      mockGetCaseData.mockImplementation(async () => {
+        return new Claim();
+      });
+      const spySave = jest.spyOn(draftStoreService, 'saveDraftClaim');
+      //When
+      await saveTaxPaymentsData('123', new GenericForm(new OnTaxPayments(YesNo.YES, AMOUNT_OWED, REASON)));
+      //Then
+      expect(spySave).toBeCalled();
+    });
+
     it('should save tax payment data successfully when claim exists but no statement of means', async () => {
       //Given
       mockGetCaseData.mockImplementation(async () => {

--- a/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployed/onTaxPaymentsService.test.ts
+++ b/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployed/onTaxPaymentsService.test.ts
@@ -80,17 +80,6 @@ describe('On Tax Payments Service', () => {
     });
   });
   describe('saveTaxPaymentsData', () => {
-    it('should save tax payment data successfully when claim does not exist', async () => {
-      //Given
-      mockGetCaseData.mockImplementation(async () => {
-        return undefined;
-      });
-      const spySave = jest.spyOn(draftStoreService, 'saveDraftClaim');
-      //When
-      await saveTaxPaymentsData('123', new GenericForm(new OnTaxPayments(YesNo.YES, AMOUNT_OWED, REASON)));
-      //Then
-      expect(spySave).toBeCalled();
-    });
     it('should save tax payment data successfully when claim exists but no statement of means', async () => {
       //Given
       mockGetCaseData.mockImplementation(async () => {

--- a/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployedAsService.test.ts
+++ b/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployedAsService.test.ts
@@ -76,17 +76,6 @@ describe('Self Employed Service', () => {
   });
 
   describe('saveSelfEmployedAsData', () => {
-    it('should save selfEmployedAs data successfully when claim does not exist', async () => {
-      //Given
-      mockGetCaseData.mockImplementation(async () => {
-        return undefined;
-      });
-      const spySave = jest.spyOn(draftStoreService, 'saveDraftClaim');
-      //When
-      await saveSelfEmployedAsData('123', new GenericForm(new SelfEmployedAsForm(JOB_TITLE, ANNUAL_TURNOVER)));
-      //Then
-      expect(spySave).toBeCalled();
-    });
     it('should save selfEmployedAs data successfully when claim exists but no statement of means', async () => {
       //Given
       mockGetCaseData.mockImplementation(async () => {

--- a/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployedAsService.test.ts
+++ b/src/test/unit/services/features/response/statementOfMeans/employment/selfEmployedAsService.test.ts
@@ -76,6 +76,18 @@ describe('Self Employed Service', () => {
   });
 
   describe('saveSelfEmployedAsData', () => {
+    it('should save selfEmployedAs data successfully when claim does not exist', async () => {
+      //Given
+      mockGetCaseData.mockImplementation(async () => {
+        return new Claim();
+      });
+      const spySave = jest.spyOn(draftStoreService, 'saveDraftClaim');
+      //When
+      await saveSelfEmployedAsData('123', new GenericForm(new SelfEmployedAsForm(JOB_TITLE, ANNUAL_TURNOVER)));
+      //Then
+      expect(spySave).toBeCalled();
+    });
+
     it('should save selfEmployedAs data successfully when claim exists but no statement of means', async () => {
       //Given
       mockGetCaseData.mockImplementation(async () => {


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CIV-5450


### Change description ###
Refactor to remove unnecessary || new Claim() as `getCaseDataFromStore` function will always return a claim


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
