### PR TITLE
CIV-0000 Add windows specific lint config (ignore CRLFs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "startwin": "SET NODE_ENV=production && ./node_modules/.bin/ts-node -r tsconfig-paths/register src/main/server.ts",
     "startwin:dev": "nodemon --config nodemon.json --exec yarn startwin",
     "lint": "sass-lint -v -q && eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:win": "yarn lint -c win.eslint.json",
     "build": "yarn webpack --config webpack.config.js",
     "build:prod": "NODE_ENV=production yarn webpack --mode production --config webpack.config.js",
     "test": "echo -c jest.config.js",

--- a/win.eslint.json
+++ b/win.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    ".eslintrc.js"
+  ],
+  "rules": {
+    "linebreak-style": "off"
+  }
+}


### PR DESCRIPTION
### JIRA link ###
N/A


### Change description ###
Adds a new yarn script to allow us to run lint on Windows. This is the same ruleset as for non-Windows but ignores invalid line-breaks (i.e. non LF). 
I will update the Ways of Working page when this is merged.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
