### PR TITLE
CIV-8577 fix wrong redirect in Types of documents to upload

### DIFF
--- a/src/main/routes/features/caseProgression/typeOfDocumentsController.ts
+++ b/src/main/routes/features/caseProgression/typeOfDocumentsController.ts
@@ -1,8 +1,8 @@
 import {NextFunction, RequestHandler, Response, Router} from 'express';
 import {
+  CP_UPLOAD_DOCUMENTS_URL,
   DEFENDANT_SUMMARY_URL,
   TYPES_OF_DOCUMENTS_URL,
-  UPLOAD_YOUR_DOCUMENTS_URL,
 } from '../../urls';
 import {AppRequest} from 'common/models/AppRequest';
 
@@ -56,7 +56,7 @@ typeOfDocumentsController.post(TYPES_OF_DOCUMENTS_URL, (async (req, res, next) =
       await renderView(res, claimId,form);
     } else {
       await saveCaseProgression(claimId, form.model, dqPropertyName);
-      res.redirect(constructResponseUrlWithIdParams(claimId, UPLOAD_YOUR_DOCUMENTS_URL));
+      res.redirect(constructResponseUrlWithIdParams(claimId, CP_UPLOAD_DOCUMENTS_URL));
     }
   } catch (error) {
     next(error);


### PR DESCRIPTION
### [JIRA link](https://tools.hmcts.net/jira/browse/CIV-8577) ###



### Problem : On Evidence Upload - Fast Track journey - on 'What types of documents do you want to upload?' page, when the boxes are ticked and the continue button is hit - the next page that shows up is the initial 'Upload Your Documents' page which is at the start of the Evidence Upload journey.  ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
