### PR TITLE
CIV-0000 CUI cannot upload ccd def file and camunda bpmns to aat directly

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -113,7 +113,7 @@ withPipeline(type, product, component) {
           ./bin/pull-latest-dmn-files.sh ${dmnBranch}
           ./bin/pull-latest-camunda-wa-files.sh ${waStandaloneBranch}
           ./bin/pull-latest-ccd-files.sh ${ccdBranch}
-          ./bin/import-ccd-definition.sh "-e *-prod.json,*HNL-nonprod.json,*ClaimantResponseLRspec-nonprod.json,*DocmosisEvents-nonprod.json,*UserEventsLRspec-nonprod.json,*ClaimantResponseLRspec-base-nonprod.json,*NotificationEventsDJSpec-nonprod.json,*DefaultJudgmentDJspec-nonprod.json,ClaimantResponseLRspec-hnl-legal-rep-nonprod.json,Categories*.json,AuthorisationCaseType*.json" ${ccdBranch}
+          ./bin/import-ccd-definition.sh "-e *-prod.json,*-shuttered.json,*HNL-nonprod.json,*ClaimantResponseLRspec-nonprod.json,*DocmosisEvents-nonprod.json,*UserEventsLRspec-nonprod.json,*ClaimantResponseLRspec-base-nonprod.json,*NotificationEventsDJSpec-nonprod.json,*DefaultJudgmentDJspec-nonprod.json,ClaimantResponseLRspec-hnl-legal-rep-nonprod.json,Categories*.json,AuthorisationCaseType*.json" ${ccdBranch}
         """
     setUrls("civil-citizen-ui-pr-${CHANGE_ID}")
   }
@@ -149,10 +149,6 @@ withPipeline(type, product, component) {
   before('smoketest:aat') {
     sh """
       eval \$(./bin/variables/load-staging-environment-variables.sh)
-      ./bin/add-roles.sh
-      ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
-      ./bin/import-ccd-definition.sh "-e *GAspec.json,*-nonprod.json,AuthorisationCaseType*.json"
-      ./bin/pull-latest-camunda-files.sh ${camundaBranch}
     """
     setUrls("aat");
   }


### PR DESCRIPTION
CIV-0000 CUI cannot upload anything that it doesn't own to aat directly unless they use staging pods. CCD def is owned by http://github.com/hmcts/civil-ccd-definition/ and camunda bpmns are owned by https://github.com/hmcts/civil-camunda-bpmn-definition