### PR TITLE
CIV-9131 Expert Evidence section - Other Party's Name

### DIFF
--- a/src/main/services/features/caseProgression/expertService.ts
+++ b/src/main/services/features/caseProgression/expertService.ts
@@ -10,8 +10,10 @@ export const getExpertContent = (claim: Claim): ClaimSummaryContent[] => {
   const sectionContent = [];
   const selectItems= [];
   // TODO check for logged user and send only the other party/parties name/s
+  // at the moment claimant's full name is always added
+  // because Case Progression can only develop relevant logic for Claimant LiP after CUI R2 is done
   selectItems.push(claim.getClaimantFullName());
-  selectItems.push(claim.getDefendantFullName());
+  // selectItems.push(claim.getDefendantFullName());
 
   if(claim.caseProgression?.defendantUploadDocuments?.expert[0]?.selected){
     sectionContent.push([buildExpertReportSection()]);


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CIV-9131


### Change description ###
Only claimant's name is available to select when defendant is uploading expert's documents
![image](https://github.com/hmcts/civil-citizen-ui/assets/18092228/8099504a-88c9-450f-a84e-e32b5fe3070e)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
