### PR TITLE
CIV-9719 Word wrap documents tab

### DIFF
--- a/src/main/assets/scss/main.scss
+++ b/src/main/assets/scss/main.scss
@@ -218,3 +218,8 @@
     animation: dotAnimation 1s infinite steps(5);
   }
 }
+
+.wordWrap {
+  word-wrap: break-word;
+}
+

--- a/src/main/views/features/dashboard/claim-summary.njk
+++ b/src/main/views/features/dashboard/claim-summary.njk
@@ -36,6 +36,7 @@
             {{ claim.legacyCaseReference }}
           </p>
 
+          <div class="wordWrap">
           {{ govukTabs({
             classes: 'tab-section',
             items: [
@@ -51,7 +52,7 @@
               }
             ]
           }) }}
-
+          </div>
           {{ contactUsForHelp(t) }}
         </div>
         {{ aboutClaimWidget({


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CIV-9719


### Change description ###
Word wrap is added to the document list box so that if a document has a name that is too long, it does not go beyond the box containing it.

![css3](https://github.com/hmcts/civil-citizen-ui/assets/93722947/6114c1c0-046e-4307-abe3-137e8ac5c39c)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
