### PR TITLE
CIV-0000 accessibility tests stage changing to after success

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -127,7 +127,7 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'src/test/functionalTests/test-results/functional/**/*'
   }
 
-  afterAlways('smoketest:preview') {
+  afterSuccess('smoketest:preview') {
         stage('Accessibility') {
             yarnBuilder.yarn('tests:a11y')
             publishHTML([
@@ -148,7 +148,7 @@ withPipeline(type, product, component) {
     setUrls("aat");
   }
 
-  afterAlways('smoketest:aat') {
+  afterSuccess('smoketest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/smokeTest/**/*'
 
     stage('Accessibility') {


### PR DESCRIPTION
this would allow accessibility stage not to run if there is a smoke test failure

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
