### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -21,12 +21,12 @@ These are the Terraform resources specifically for the Civil Citizen UI Applicat
 |------|--------|---------|
 | <a name="module_citizen-ui-draft-store"></a> [citizen-ui-draft-store](#module\_citizen-ui-draft-store) | git@github.com:hmcts/cnp-module-redis | master |
 | <a name="module_key-vault"></a> [key-vault](#module\_key-vault) | git@github.com:hmcts/cnp-module-key-vault | master |
+| <a name="module_application-insights"></a> [application-insights](#module\_application-insights) | git@github.com:hmcts/terraform-module-application-insights | main |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azurerm_application_insights.web](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_key_vault_secret.app_insights_instrumentation_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.draft_store_access_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -1,8 +1,17 @@
-resource "azurerm_application_insights" "web" {
-  name                = "${var.product}-${var.component}-${var.env}"
-  location            = azurerm_resource_group.rg.location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env      = var.env
+  product  = var.product
+  location = azurerm_resource_group.rg.location
+  name     = "${var.product}-${var.component}"
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
-  tags                = var.common_tags
+
+  common_tags = var.common_tags
 }
 
+moved {
+  from = azurerm_application_insights.web
+  to   = module.application_insights.azurerm_application_insights.this
+}

--- a/infrastructure/key-vault-secrets.tf
+++ b/infrastructure/key-vault-secrets.tf
@@ -1,11 +1,11 @@
 resource "azurerm_key_vault_secret" "app_insights_instrumentation_key" {
   name         = "appinsights-instrumentation-key"
-  value        = azurerm_application_insights.web.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.key-vault.key_vault_id
 
   content_type = "secret"
   tags = merge(var.common_tags, {
-    "source" : "appinsights ${azurerm_application_insights.web.name}"
+    "source" : "appinsights ${module.application_insights.name}"
   })
 
   depends_on = [
@@ -14,12 +14,12 @@ resource "azurerm_key_vault_secret" "app_insights_instrumentation_key" {
 }
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "appinsights-connection-string"
-  value        = azurerm_application_insights.web.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.key-vault.key_vault_id
 
   content_type = "secret"
   tags = merge(var.common_tags, {
-    "source" : "appinsights ${azurerm_application_insights.web.name}"
+    "source" : "appinsights ${module.application_insights.name}"
   })
 
   depends_on = [


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.