### PR TITLE
CIV-15038 Fix bug cancel page in check your answer screen

### DIFF
--- a/src/main/routes/features/caseProgression/checkAnswersController.ts
+++ b/src/main/routes/features/caseProgression/checkAnswersController.ts
@@ -25,7 +25,7 @@ const documentUploadCheckAnswerController = Router();
 const civilServiceApiBaseUrl = config.get<string>('services.civilService.url');
 const civilServiceClient: CivilServiceClient = new CivilServiceClient(civilServiceApiBaseUrl);
 function renderView(res: Response, form: GenericForm<DocumentUploadSubmissionForm>, claim: Claim, claimId: string, isClaimant: boolean, lang: string) {
-  const topPageContents = getTopElements(claim);
+  const topPageContents = getTopElements(claim, claimId);
   let summarySections: DocumentUploadSections;
   const isSmallClaims = claim.isSmallClaimsTrackDQ;
   const backLinkUrl = constructResponseUrlWithIdParams(claimId, CP_UPLOAD_DOCUMENTS_URL);
@@ -36,7 +36,7 @@ function renderView(res: Response, form: GenericForm<DocumentUploadSubmissionFor
     summarySections = getSummarySections(claim.caseProgression.defendantDocuments, claimId, isSmallClaims, lang);
   }
   const bottomPageContents = getBottomElements();
-  const cancelUrl = constructResponseUrlWithIdParams(claim.id, CP_EVIDENCE_UPLOAD_CANCEL);
+  const cancelUrl = constructResponseUrlWithIdParams(claimId, CP_EVIDENCE_UPLOAD_CANCEL);
 
   res.render(checkAnswersViewPath, {
     form, topPageContents, summarySections, bottomPageContents, isSmallClaims, cancelUrl, backLinkUrl,

--- a/src/main/services/features/caseProgression/checkYourAnswers/checkAnswersService.ts
+++ b/src/main/services/features/caseProgression/checkYourAnswers/checkAnswersService.ts
@@ -48,12 +48,12 @@ export const getSummarySections = (uploadedDocuments: UploadDocumentsUserForm, c
   };
 };
 
-export const getTopElements = (claim:Claim): ClaimSummarySection[] => {
+export const getTopElements = (claim:Claim, claimId: string): ClaimSummarySection[] => {
 
   return new PageSectionBuilder()
     .addMicroText('PAGES.DASHBOARD.HEARINGS.HEARING')
     .addMainTitle('PAGES.UPLOAD_EVIDENCE_DOCUMENTS.CHECK_YOUR_ANSWERS_TITLE')
-    .addLeadParagraph('COMMON.CASE_NUMBER_PARAM', {claimId:caseNumberPrettify( claim.id)}, 'govuk-!-margin-bottom-1')
+    .addLeadParagraph('COMMON.CASE_NUMBER_PARAM', {claimId:caseNumberPrettify(claimId)}, 'govuk-!-margin-bottom-1')
     .addLeadParagraph('COMMON.CLAIM_AMOUNT_WITH_VALUE', {claimAmount: currencyFormatWithNoTrailingZeros(claim.totalClaimAmount)})
     .addInsetText('PAGES.UPLOAD_EVIDENCE_DOCUMENTS.CHECK_YOUR_ANSWERS_WARNING_FULL')
     .build();

--- a/src/test/unit/services/features/caseProgression/checkYourAnswers/checkAnswersService.test.ts
+++ b/src/test/unit/services/features/caseProgression/checkYourAnswers/checkAnswersService.test.ts
@@ -92,7 +92,7 @@ describe('checkAnswersServiceTest', () => {
       claim.respondent1.partyDetails = {partyName: 'John Smith', firstName: 'John', lastName: 'Smith', title: 'Dr'} as PartyDetails;
 
       //when
-      const topElementsActual = getTopElements(claim);
+      const topElementsActual = getTopElements(claim, claim.id);
       //then
       const topElementsExpected = [
         {type: ClaimSummaryType.MICRO_TEXT, data: {text: 'PAGES.DASHBOARD.HEARINGS.HEARING'}},


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CIV-15038


### Change description ###
The claim id is now sent to correctly generate the cancellation page. 
In addition, the id shown on the check your answers screen has been fixed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
