### PR TITLE
CIV-17029 Set Aside a Judgement GA Lip Without Notice Application Updates

### DIFF
--- a/src/test/functionalTests/citizenFeatures/GA/steps/createGASteps.js
+++ b/src/test/functionalTests/citizenFeatures/GA/steps/createGASteps.js
@@ -50,10 +50,23 @@ const uploadN245FormPage = new N245Upload();
 class createGASteps {
 
   async askToSetAsideJudgementGA(caseRef, parties, communicationType = 'notice') {
-    //Cannot be withoutnotice
     const caseNumber = StringUtilsComponent.StringUtilsComponent.formatClaimReferenceToAUIDisplayFormat(caseRef);
     const applicationType = 'Set aside (remove) a judgment';
-    const feeAmount = '313';
+    
+    let feeAmount;
+
+    switch (communicationType) {
+      case 'consent':
+        feeAmount = '123';
+        break;
+      case 'notice':
+        feeAmount = '313';
+        break;
+      case 'withoutnotice':
+        feeAmount = '123';
+        break;
+    }
+    
     await I.waitForContent('Contact the court to request a change to my case', 60);
     await I.click('Contact the court to request a change to my case');
     await I.amOnPage(`case/${caseRef}/general-application/application-type`);
@@ -69,6 +82,13 @@ class createGASteps {
       await agreementFromOtherPartyPage.verifyPageContent(applicationType);
       await agreementFromOtherPartyPage.nextAction('No');
       await agreementFromOtherPartyPage.nextAction('Continue');
+      if (communicationType == 'notice') {
+        await informOtherPartiesPage.verifyPageContent(applicationType);
+        await informOtherPartiesPage.selectAndVerifyDoInformOption();
+      } else {
+        await informOtherPartiesPage.verifyPageContent(applicationType);
+        await informOtherPartiesPage.selectAndVerifyDontInformOption();
+      }
     }
 
     await applicationCostsPage.verifyPageContent(applicationType, feeAmount);


### PR DESCRIPTION
### Change description ###

As per https://tools.hmcts.net/jira/browse/CIV-16994 Lips are now able to make a without notice 'Set aside a judgement' general application. GA Functional Tests have been updated to allow for without notice applications.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
