### PR TITLE
DTSCCI-5175: start test harness integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: yarn install && yarn playwright install
       - name: Build
         run: yarn build
+      - name: Run integration route tests
+        run: yarn test:integration
       - name: Pull WireMock mappings
         run: yarn wiremock:pull
       - name: Starting WireMock, starting ui, wait and run e2e test

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -213,6 +213,7 @@ withPipeline(type, product, component) {
 
   afterSuccess('build') {
     yarnBuilder.yarn('build')
+    yarnBuilder.yarn('test:integration')
   }
 
   before('smoketest:preview') {

--- a/README.md
+++ b/README.md
@@ -96,11 +96,14 @@ the following command:
 $ yarn test
 ```
 
-Here's how to run functional tests (the template contains just one sample test):
+Here's how to run route integration tests (Jest + Supertest):
 
 ```bash
-$ yarn test:routes
+$ yarn test:integration
 ```
+
+(`yarn test:routes` is kept as an alias and is also used by `test:integration`.)
+These integration tests run in CI as part of the main pipeline.
 
 Running accessibility tests:
 

--- a/jest.functionaltest.config.js
+++ b/jest.functionaltest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testRegex: '(/src/integration-test/.*\\.(test|spec))\\.(ts|js)$',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.ts?$': ['ts-jest', { tsconfig: 'tsconfig.jest.integration.json' }],
     '.*/node_modules/(@exodus/bytes|html-encoding-sniffer|@asamuzakjp/css-color|cssstyle|@csstools|parse5|jsdom|@tootallnate/once)/.+\\.(js|mjs|cjs)$': 'babel-jest',
   },
   transformIgnorePatterns: [

--- a/jest.functionaltest.config.js
+++ b/jest.functionaltest.config.js
@@ -1,16 +1,36 @@
 module.exports = {
   roots: ['<rootDir>/src/integration-test'],
-  "testRegex": "(/src/integration-test/.*|\\.(test|spec))\\.(ts|js)$",
-  "testEnvironment": "node",
+  testRegex: '(/src/integration-test/.*\\.(test|spec))\\.(ts|js)$',
+  testEnvironment: 'node',
   transform: {
     '^.+\\.ts?$': 'ts-jest',
+    '.*/node_modules/(@exodus/bytes|html-encoding-sniffer|@asamuzakjp/css-color|cssstyle|@csstools|parse5|jsdom|@tootallnate/once)/.+\\.(js|mjs|cjs)$': 'babel-jest',
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@exodus/bytes|html-encoding-sniffer|@asamuzakjp/css-color|cssstyle|@csstools|parse5|jsdom|@tootallnate/once)/)',
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^otplib$': '<rootDir>/__mocks__/otplib.js',
+    '^common/(.*)$': '<rootDir>/src/main/common/$1',
+    '^models/(.*)$': '<rootDir>/src/main/common/models/$1',
+    '^form/(.*)$': '<rootDir>/src/main/common/form/$1',
+    '^modules/(.*)$': '<rootDir>/src/main/modules/$1',
+    '^client/(.*)$': '<rootDir>/src/main/app/client/$1',
+    '^routes/(.*)$': '<rootDir>/src/main/routes/$1',
+    '^services/(.*)$': '<rootDir>/src/main/services/$1',
+    '^app/auth/(.*)$': '<rootDir>/src/main/app/auth/$1',
+  },
+  setupFilesAfterEnv: [
+    './jest.setup.redis-mock.js',
+    './jest.setup.js',
+    '<rootDir>/src/integration-test/setup/testSetup.ts',
+  ],
   reporters: [
     'default',
-    [ 'jest-junit', {
-      outputDirectory: "./functional-output",
-      outputName: "test-output.html"
-    } ]
+    ['jest-junit', {
+      outputDirectory: './functional-output',
+      outputName: 'test-output.html',
+    }],
   ],
-}
+};

--- a/jest.smoketest.config.js
+++ b/jest.smoketest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testRegex: '(/src/integration-test/.*\\.(test|spec))\\.(ts|js)$',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.ts?$': ['ts-jest', { tsconfig: 'tsconfig.jest.integration.json' }],
     '.*/node_modules/(@exodus/bytes|html-encoding-sniffer|@asamuzakjp/css-color|cssstyle|@csstools|parse5|jsdom|@tootallnate/once)/.+\\.(js|mjs|cjs)$': 'babel-jest',
   },
   transformIgnorePatterns: [

--- a/jest.smoketest.config.js
+++ b/jest.smoketest.config.js
@@ -1,16 +1,36 @@
 module.exports = {
   roots: ['<rootDir>/src/integration-test'],
-  "testRegex": "(/src/integration-test/.*|\\.(test|spec))\\.(ts|js)$",
-  "testEnvironment": "node",
+  testRegex: '(/src/integration-test/.*\\.(test|spec))\\.(ts|js)$',
+  testEnvironment: 'node',
   transform: {
     '^.+\\.ts?$': 'ts-jest',
+    '.*/node_modules/(@exodus/bytes|html-encoding-sniffer|@asamuzakjp/css-color|cssstyle|@csstools|parse5|jsdom|@tootallnate/once)/.+\\.(js|mjs|cjs)$': 'babel-jest',
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@exodus/bytes|html-encoding-sniffer|@asamuzakjp/css-color|cssstyle|@csstools|parse5|jsdom|@tootallnate/once)/)',
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^otplib$': '<rootDir>/__mocks__/otplib.js',
+    '^common/(.*)$': '<rootDir>/src/main/common/$1',
+    '^models/(.*)$': '<rootDir>/src/main/common/models/$1',
+    '^form/(.*)$': '<rootDir>/src/main/common/form/$1',
+    '^modules/(.*)$': '<rootDir>/src/main/modules/$1',
+    '^client/(.*)$': '<rootDir>/src/main/app/client/$1',
+    '^routes/(.*)$': '<rootDir>/src/main/routes/$1',
+    '^services/(.*)$': '<rootDir>/src/main/services/$1',
+    '^app/auth/(.*)$': '<rootDir>/src/main/app/auth/$1',
+  },
+  setupFilesAfterEnv: [
+    './jest.setup.redis-mock.js',
+    './jest.setup.js',
+    '<rootDir>/src/integration-test/setup/testSetup.ts',
+  ],
   reporters: [
     'default',
-    [ 'jest-junit', {
-      outputDirectory: "./smoke-output",
-      outputName: "test-output.html"
-    } ]
+    ['jest-junit', {
+      outputDirectory: './smoke-output',
+      outputName: 'test-output.html',
+    }],
   ],
-}
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:prod": "NODE_ENV=production yarn webpack --mode production --config webpack.config.js",
     "test": "echo -c jest.config.js",
     "test:coverage": "LOG_LEVEL=OFF jest --coverage --maxWorkers=8 --logHeapUsage --silent",
+    "test:routes": "jest -c jest.functionaltest.config.js --runInBand",
+    "test:integration": "yarn test:routes",
     "test:a11y": "echo 'a11y tests are ran through GitHub actions as a mandatory step in order to save time on the main pipeline and unable to mock at the moment.'",
     "tests:a11y": "NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ENV=test LOG_LEVEL=ERROR mocha --exit --reporter mochawesome --require ts-node/register --require tsconfig-paths/register src/test/a11y/a11y.mock-test.ts --timeout 60000 --reporter-options reportDir=functional-output/accessibility-report,inlineAssets=true,reportTitle=civil-citizen-ui",
     "tests:a11y:parallel": "./src/test/a11y/run-parallel-a11y-tests.sh",

--- a/src/integration-test/routes/dashboard/viewClaimantInformation.integration.test.ts
+++ b/src/integration-test/routes/dashboard/viewClaimantInformation.integration.test.ts
@@ -1,0 +1,35 @@
+import request from 'supertest';
+import {app} from '../../../main/app';
+import {VIEW_CLAIMANT_INFO} from '../../../main/routes/urls';
+import {civilServiceClientMock} from '../../setup/sharedMocks';
+import {Claim} from '../../../main/common/models/claim';
+import {Party} from '../../../main/common/models/party';
+import {PartyType} from '../../../main/common/models/partyType';
+import {PartyDetails} from '../../../main/common/form/models/partyDetails';
+
+describe('Integration: View claimant information route', () => {
+  it('renders claimant information page from mocked claim data', async () => {
+    const claim = new Claim();
+    claim.id = '000MC001';
+    claim.totalClaimAmount = 500;
+    claim.claimantResponse = {mediation: {}} as never;
+    claim.applicant1 = new Party();
+    claim.applicant1.type = PartyType.INDIVIDUAL;
+    claim.applicant1.partyDetails = new PartyDetails({
+      individualFirstName: 'Jane',
+      individualLastName: 'Doe',
+    });
+
+    civilServiceClientMock.retrieveClaimDetails.mockResolvedValue(claim);
+
+    await request(app)
+      .get(VIEW_CLAIMANT_INFO.replace(':id', '000MC001'))
+      .expect((res) => {
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('View information about the claimant');
+        expect(res.text).toContain('Case number: 000M C001');
+        expect(res.text).toContain('Claim amount: £500.00');
+      });
+  });
+});
+

--- a/src/integration-test/setup/sharedMocks.ts
+++ b/src/integration-test/setup/sharedMocks.ts
@@ -1,0 +1,97 @@
+const launchDarklyClientMock = {
+  isServiceShuttered: jest.fn().mockResolvedValue(false),
+  updateE2EKey: jest.fn().mockResolvedValue(undefined),
+  isCarmEnabledForCase: jest.fn().mockResolvedValue(false),
+  isGaForLipsEnabled: jest.fn().mockResolvedValue(false),
+  isQueryManagementEnabled: jest.fn().mockResolvedValue(false),
+  isWelshEnabledForMainCase: jest.fn().mockResolvedValue(false),
+};
+
+jest.mock('express-async-errors', () => ({}), {virtual: true});
+jest.mock('@hmcts/nodejs-logging', () => ({
+  Logger: {
+    getLogger: jest.fn(() => ({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    })),
+  },
+}));
+
+export const civilServiceClientMock = {
+  retrieveClaimDetails: jest.fn(),
+  submitEvent: jest.fn(),
+};
+
+export const gaServiceClientMock = {
+  getApplication: jest.fn(),
+  submitApplication: jest.fn(),
+};
+
+export const paymentServiceMock = {
+  getFeePaymentRedirectInformation: jest.fn(),
+  getFeePaymentStatus: jest.fn(),
+};
+
+export const dmStoreClientMock = {
+  retrieveDocumentByDocumentId: jest.fn(),
+};
+
+jest.mock('modules/oidc', () => ({
+  OidcMiddleware: class {
+    public enableFor(): void {
+      // Intentionally no-op for integration harness.
+    }
+  },
+}));
+
+jest.mock('modules/helmet', () => ({
+  Helmet: class {
+    public enableFor(): void {
+      // Intentionally no-op for integration harness.
+    }
+  },
+}));
+
+jest.mock('modules/draft-store', () => ({
+  DraftStoreClient: class {
+    public enableFor(): void {
+      // Intentionally no-op for integration harness.
+    }
+  },
+}));
+
+jest.mock('modules/properties-volume', () => ({
+  PropertiesVolume: class {
+    public enableFor(): void {
+      // Intentionally no-op for integration harness.
+    }
+  },
+}));
+
+jest.mock('modules/utilityService', () => {
+  const actual = jest.requireActual('modules/utilityService');
+  const session = require('express-session');
+  return {
+    ...actual,
+    getRedisStoreForSession: jest.fn(() => new session.MemoryStore()),
+  };
+});
+
+jest.mock('app/auth/launchdarkly/launchDarklyClient', () => launchDarklyClientMock);
+
+jest.mock('client/civilServiceClient', () => ({
+  CivilServiceClient: jest.fn().mockImplementation(() => civilServiceClientMock),
+}));
+
+jest.mock('client/gaServiceClient', () => ({
+  GaServiceClient: jest.fn().mockImplementation(() => gaServiceClientMock),
+}));
+
+jest.mock('services/features/feePayment/feePaymentService', () => paymentServiceMock);
+
+jest.mock('client/dmStoreClient', () => ({
+  DmStoreClient: jest.fn().mockImplementation(() => dmStoreClientMock),
+}));
+

--- a/src/integration-test/setup/testSetup.ts
+++ b/src/integration-test/setup/testSetup.ts
@@ -1,0 +1,6 @@
+import './sharedMocks';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+

--- a/tsconfig.jest.integration.json
+++ b/tsconfig.jest.integration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es6",
+    "isolatedModules": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es6",
-    "isolatedModules": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSCCI-5175

Enable Citizen UI Integration Test Harness

### Change description ###


Description:
Create a proper src/integration-test test harness for civil-citizen-ui. The repo already has jest.functionaltest.config.js and jest.smoketest.config.js pointing at src/integration-test, but that directory does not exist. package.json also references test:routes in cichecks, but no script exists. This ticket establishes the foundation for moving browser-heavy E2E coverage into faster server-side integration tests.

Scope:
Add src/integration-test folder structure.
Add yarn test:integration or restore yarn test:routes.
Use supertest(app) for rendered route assertions.
Provide shared mocks for OIDC, LaunchDarkly, draft-store, civil-service, GA service, payments and document clients.
Add one working example against a dashboard or task-list route.

Acceptance criteria:
Integration tests can run locally with one command.
CI script references are corrected.
Test setup does not require IDAM, CCD, Pay, DM Store or WireMock.
A sample route integration test proves mocked claim data can render a real page.

LOCAL BUILD
<img width="693" height="173" alt="Screenshot 2026-04-17 at 13 38 45" src="https://github.com/user-attachments/assets/d039bb8a-b7f1-4e70-961f-256432bf2ab7" />


JENKINS
<img width="800" height="325" alt="Screenshot 2026-04-20 at 10 55 37" src="https://github.com/user-attachments/assets/1288c686-1966-4b93-a660-f7060d6d9afe" />




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
