### PR TITLE
DTSCCI-4291 Harden service exposure and scan posture for security

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,6 @@
 useCSRFProtection: true
 security:
-  referrerPolicy: 'origin'
+  referrerPolicy: 'strict-origin-when-cross-origin'
 port: 3001
 timeout: 30000
 services:

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -137,21 +137,6 @@ const setDefaultHeaders: express.RequestHandler = (_req, res, next) => {
     'no-cache, max-age=0, must-revalidate, no-store',
   );
 
-  res.setHeader(
-    'Access-Control-Allow-Origin',
-    '*',
-  );
-
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept',
-  );
-
-  res.setHeader(
-    'access-control-allow-methods',
-    'GET,POST,OPTIONS,PUT,DELETE',
-  );
-
   next();
 };
 
@@ -159,7 +144,6 @@ export {app};
 app.use(cookieParser());
 app.use(setLanguage);
 app.use(favicon(path.join(__dirname, 'public', 'assets', 'images', 'favicon.ico')) as any);
-app.use(express.static(path.join(__dirname, 'public')));
 
 app.use(express.json({ limit: '500mb' }));
 app.use(express.urlencoded({ limit: '500mb', extended: true }));
@@ -202,6 +186,7 @@ app.use(setCaseReferenceCookie({secure: productionMode, maxAge: cookieMaxAge}));
 app.enable('trust proxy');
 new Nunjucks(developmentMode).enableFor(app);
 new Helmet(config.get('security')).enableFor(app);
+app.use(express.static(path.join(__dirname, 'public')));
 new HealthCheck().enableFor(app);
 
 app.use(SIGN_OUT_URL, deleteGAGuard);
@@ -219,7 +204,7 @@ if(e2eTestMode){
       // Send a response back to the client
       res.status(200).json({ message: 'Flag updated successfully' });
     } catch (error) {
-      res.status(500).json({ message: 'Error changing the flag', error });
+      res.status(500).json({ message: 'Error changing the flag' });
     }
   });
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -204,7 +204,7 @@ if(e2eTestMode){
       // Send a response back to the client
       res.status(200).json({ message: 'Flag updated successfully' });
     } catch (error) {
-      res.status(500).json({ message: 'Error changing the flag' });
+      res.status(500).json({ message: 'Error changing the flag', error });
     }
   });
 

--- a/src/main/modules/cookie/caseReferenceCookie.ts
+++ b/src/main/modules/cookie/caseReferenceCookie.ts
@@ -42,7 +42,7 @@ const applyCookie = (req: AppRequest, res: Response, overrideReference?: unknown
     if (req.cookies?.[CASE_REFERENCE_COOKIE_NAME] !== normalisedReference) {
       res.cookie(CASE_REFERENCE_COOKIE_NAME, normalisedReference, {
         maxAge: storedCookieOptions.maxAge,
-        httpOnly: false,
+        httpOnly: true,
         secure: storedCookieOptions.secure,
         sameSite: 'lax',
         path: '/',

--- a/src/main/routes/features/public/cookiesController.ts
+++ b/src/main/routes/features/public/cookiesController.ts
@@ -24,7 +24,7 @@ cookiesController.post(COOKIES_URL, (async (req: AppRequest<CookiesModel>, res: 
   const cookie = req.cookies['money-claims-cookie-preferences'] ? JSON.parse(req.cookies['money-claims-cookie-preferences']) : {};
   cookie.analytics = req.body.analytics;
   cookie.apm = req.body.apm;
-  res.cookie('money-claims-cookie-preferences', cookie);
+  res.cookie('money-claims-cookie-preferences', cookie, {sameSite: 'lax'});
   res.render(cookiesViewPath, {
     cookiePreferences: cookie,
     redirectUrl: DASHBOARD_URL,

--- a/src/main/routes/features/public/eligibility/claimAgainstGovernmentController.ts
+++ b/src/main/routes/features/public/eligibility/claimAgainstGovernmentController.ts
@@ -33,7 +33,7 @@ claimAgainstGovernmentController.post(ELIGIBILITY_GOVERNMENT_DEPARTMENT_URL, (as
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.governmentDepartment = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.NO
       ? res.redirect(ELIGIBILITY_DEFENDANT_AGE_URL)
       : res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.GOVERNMENT_DEPARTMENT));

--- a/src/main/routes/features/public/eligibility/claimTypeController.ts
+++ b/src/main/routes/features/public/eligibility/claimTypeController.ts
@@ -28,7 +28,7 @@ claimTypeController.post(ELIGIBILITY_CLAIM_TYPE_URL, async (req: Request, res: R
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.claimType = req.body.claimType;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     switch (claimType.option) {
       case ClaimTypeOptions.MORE_THAN_ONE_PERSON_OR_ORGANISATION:
         res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.MULTIPLE_CLAIMANTS));

--- a/src/main/routes/features/public/eligibility/claimantAddressEligibilityController.ts
+++ b/src/main/routes/features/public/eligibility/claimantAddressEligibilityController.ts
@@ -31,7 +31,7 @@ claimantAddressEligibilityController.post(ELIGIBILITY_CLAIMANT_ADDRESS_URL, (asy
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.eligibleClaimantAddress = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_TENANCY_DEPOSIT_URL)
       : res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.CLAIMANT_ADDRESS));

--- a/src/main/routes/features/public/eligibility/claimantOver18EligibilityController.ts
+++ b/src/main/routes/features/public/eligibility/claimantOver18EligibilityController.ts
@@ -33,7 +33,7 @@ claimantOver18EligibilityController.post(ELIGIBILITY_CLAIMANT_AGE_URL, (req, res
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.claimantOver18 = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_HELP_WITH_FEES_URL)
       : res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.UNDER_18_CLAIMANT));

--- a/src/main/routes/features/public/eligibility/defendantAddressEligibilityController.ts
+++ b/src/main/routes/features/public/eligibility/defendantAddressEligibilityController.ts
@@ -31,7 +31,7 @@ defendantAddressEligibilityController.post(ELIGIBILITY_DEFENDANT_ADDRESS_URL, (r
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.eligibleDefendantAddress = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_CLAIM_TYPE_URL)
       : res.redirect(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL + '?reason=defendant-address');

--- a/src/main/routes/features/public/eligibility/defendantAgeEligibilityController.ts
+++ b/src/main/routes/features/public/eligibility/defendantAgeEligibilityController.ts
@@ -34,7 +34,7 @@ defendantAgeEligibilityController.post(ELIGIBILITY_DEFENDANT_AGE_URL, (async (re
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.eligibilityDefendantAge = form.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     form.model.option === AgeEligibilityOptions.NO
       ? res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.UNDER_18_DEFENDANT))
       : res.redirect(ELIGIBILITY_CLAIMANT_AGE_URL);

--- a/src/main/routes/features/public/eligibility/helpWithFeesEligibilityController.ts
+++ b/src/main/routes/features/public/eligibility/helpWithFeesEligibilityController.ts
@@ -31,7 +31,7 @@ helpWithFeesEligibilityController.post(ELIGIBILITY_HELP_WITH_FEES_URL, async (re
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.eligibleHelpWithFees = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_INFORMATION_ABOUT_HELP_WITH_FEES_URL)
       : res.redirect(ELIGIBLE_FOR_THIS_SERVICE_URL);

--- a/src/main/routes/features/public/eligibility/helpWithFeesReferenceEligibilityController.ts
+++ b/src/main/routes/features/public/eligibility/helpWithFeesReferenceEligibilityController.ts
@@ -29,7 +29,7 @@ helpWithFeesReferenceEligibilityController.post(ELIGIBILITY_HELP_WITH_FEES_REFER
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.hwfReference = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_HWF_ELIGIBLE_REFERENCE_URL)
       : res.redirect(ELIGIBILITY_HWF_ELIGIBLE_URL);

--- a/src/main/routes/features/public/eligibility/knownClaimAmountController.ts
+++ b/src/main/routes/features/public/eligibility/knownClaimAmountController.ts
@@ -33,7 +33,7 @@ knownClaimAmountController.post(ELIGIBILITY_KNOWN_CLAIM_AMOUNT_URL, (req, res) =
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.knownClaimAmount = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_SINGLE_DEFENDANT_URL)
       : res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.CLAIM_VALUE_NOT_KNOWN));

--- a/src/main/routes/features/public/eligibility/singleDefendantController.ts
+++ b/src/main/routes/features/public/eligibility/singleDefendantController.ts
@@ -31,7 +31,7 @@ singleDefendantController.post(ELIGIBILITY_SINGLE_DEFENDANT_URL, (req, res) => {
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.singleDefendant = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL + '?reason=multiple-defendants')
       : res.redirect(ELIGIBILITY_DEFENDANT_ADDRESS_URL);

--- a/src/main/routes/features/public/eligibility/someUsefulInfoFeesController.ts
+++ b/src/main/routes/features/public/eligibility/someUsefulInfoFeesController.ts
@@ -30,7 +30,7 @@ someUsefulInfoFeesController.post(ELIGIBILITY_INFORMATION_FEES_URL, (req, res) =
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.someUsefulInfoFees = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(ELIGIBILITY_APPLY_HELP_FEES_URL)
       : res.redirect(ELIGIBILITY_HELP_WITH_FEES_URL);

--- a/src/main/routes/features/public/eligibility/tenancyDepositController.ts
+++ b/src/main/routes/features/public/eligibility/tenancyDepositController.ts
@@ -32,7 +32,7 @@ tenancyDepositController.post(ELIGIBILITY_TENANCY_DEPOSIT_URL, (req, res) => {
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.tenancyDeposit = genericYesNoForm.model.option;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     genericYesNoForm.model.option === YesNo.YES
       ? res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.CLAIM_IS_FOR_TENANCY_DEPOSIT))
       : res.redirect(ELIGIBILITY_GOVERNMENT_DEPARTMENT_URL);

--- a/src/main/routes/features/public/eligibility/totalAmountController.ts
+++ b/src/main/routes/features/public/eligibility/totalAmountController.ts
@@ -28,7 +28,7 @@ totalAmountEligibilityController.post(ELIGIBILITY_CLAIM_VALUE_URL, async (req: R
   } else {
     const cookie = req.cookies['eligibility'] ? req.cookies['eligibility'] : {};
     cookie.totalAmount = req.body.totalAmount;
-    res.cookie('eligibility', cookie);
+    res.cookie('eligibility', cookie, {httpOnly: true, sameSite: 'lax'});
     switch (totalAmount.option) {
       case TotalAmountOptions.OVER_25000:
         res.redirect(constructUrlWithNotEligibleReason(NOT_ELIGIBLE_FOR_THIS_SERVICE_URL, NotEligibleReason.CLAIM_VALUE_OVER_25000));

--- a/src/test/unit/modules/cookie/caseReferenceCookie.test.ts
+++ b/src/test/unit/modules/cookie/caseReferenceCookie.test.ts
@@ -56,7 +56,7 @@ describe('caseReferenceCookie middleware', () => {
     expect(res.cookie).toHaveBeenCalledWith(
       CASE_REFERENCE_COOKIE_NAME,
       '1645882162449409',
-      expect.objectContaining({httpOnly: false, maxAge}),
+      expect.objectContaining({httpOnly: true, maxAge}),
     );
     expect(res.clearCookie).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
@@ -72,7 +72,7 @@ describe('caseReferenceCookie middleware', () => {
     expect(res.cookie).toHaveBeenCalledWith(
       CASE_REFERENCE_COOKIE_NAME,
       '1234567890123456',
-      expect.objectContaining({httpOnly: false, maxAge}),
+      expect.objectContaining({httpOnly: true, maxAge}),
     );
     expect(res.clearCookie).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe('caseReferenceCookie middleware', () => {
     expect(res.cookie).toHaveBeenCalledWith(
       CASE_REFERENCE_COOKIE_NAME,
       'ABC123456789',
-      expect.objectContaining({httpOnly: false, maxAge}),
+      expect.objectContaining({httpOnly: true, maxAge}),
     );
   });
 


### PR DESCRIPTION

### JIRA link ###
DTSCCI-4291

### Change description ###

- Remove wildcard CORS: Stripped `Access-Control-Allow-Origin: *` and related permissive CORS headers from `setDefaultHeaders` in `app.ts`. Dynatrace-specific CORS is already handled separately in `helmet/index.ts`.
- Harden cookies: Set `httpOnly: true` on the caseReference cookie; added `httpOnly: true` and `sameSite: 'lax'` to all eligibility cookies; added `sameSite: 'lax'` to the money-claims-cookie-preferences cookie.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
