### PR TITLE
DTSCCI-5714: Capture full App Insights telemetry in non-prod environments

### DIFF
--- a/src/main/modules/appinsights/index.ts
+++ b/src/main/modules/appinsights/index.ts
@@ -12,8 +12,30 @@ export class AppInsights {
         .setSendLiveMetrics(true)
         .start();
 
-      appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = 'civil-citizen-ui';
-      appInsights.defaultClient.trackTrace({message: 'App insights activated'});
+      const client = appInsights.defaultClient;
+      client.context.tags[client.context.keys.cloudRole] = 'civil-citizen-ui';
+
+      // Non-prod only: capture all telemetry to aid diagnosis (e.g. perftest load runs,
+      // where default sampling drops ~99% of telemetry and hides failures). Prod is left
+      // untouched so its telemetry volume/cost is unchanged.
+      if (process.env.LAUNCH_DARKLY_ENV && process.env.LAUNCH_DARKLY_ENV !== 'prod') {
+        client.config.samplingPercentage = 100;
+
+        // Belt-and-braces: never sample out failures, even if a workspace/component data
+        // cap re-imposes sampling. The sampling processor keeps anything with sampleRate >= 100.
+        client.addTelemetryProcessor((envelope: { data: { baseType: string; baseData: { success?: boolean } } }) => {
+          const baseType = envelope.data.baseType;
+          const baseData = envelope.data.baseData;
+          if (baseType === 'ExceptionData'
+            || (baseType === 'RequestData' && baseData?.success === false)
+            || (baseType === 'RemoteDependencyData' && baseData?.success === false)) {
+            (envelope as unknown as { sampleRate: number }).sampleRate = 100;
+          }
+          return true;
+        });
+      }
+
+      client.trackTrace({message: 'App insights activated'});
     } else {
       logger.error('App Insights instrumentation key not set');
     }

--- a/src/main/modules/appinsights/index.ts
+++ b/src/main/modules/appinsights/index.ts
@@ -4,6 +4,25 @@ const appInsights = require('applicationinsights');
 const {Logger} = require('@hmcts/nodejs-logging');
 const logger = Logger.getLogger('appInsights');
 
+interface TelemetryEnvelope {
+  sampleRate: number;
+  data: { baseType: string; baseData: { success?: boolean } };
+}
+
+/**
+ * Belt-and-braces: never sample out failures, even if a workspace/component data cap re-imposes
+ * sampling. The SDK's sampling processor keeps anything with sampleRate >= 100.
+ */
+export const keepFailuresTelemetryProcessor = (envelope: TelemetryEnvelope): boolean => {
+  const {baseType, baseData} = envelope.data;
+  if (baseType === 'ExceptionData'
+    || (baseType === 'RequestData' && baseData?.success === false)
+    || (baseType === 'RemoteDependencyData' && baseData?.success === false)) {
+    envelope.sampleRate = 100;
+  }
+  return true;
+};
+
 export class AppInsights {
   enable(): void {
     const instrumentationKey = config.get<string>('appInsights.instrumentationKey');
@@ -20,19 +39,7 @@ export class AppInsights {
       // untouched so its telemetry volume/cost is unchanged.
       if (process.env.LAUNCH_DARKLY_ENV && process.env.LAUNCH_DARKLY_ENV !== 'prod') {
         client.config.samplingPercentage = 100;
-
-        // Belt-and-braces: never sample out failures, even if a workspace/component data
-        // cap re-imposes sampling. The sampling processor keeps anything with sampleRate >= 100.
-        client.addTelemetryProcessor((envelope: { data: { baseType: string; baseData: { success?: boolean } } }) => {
-          const baseType = envelope.data.baseType;
-          const baseData = envelope.data.baseData;
-          if (baseType === 'ExceptionData'
-            || (baseType === 'RequestData' && baseData?.success === false)
-            || (baseType === 'RemoteDependencyData' && baseData?.success === false)) {
-            (envelope as unknown as { sampleRate: number }).sampleRate = 100;
-          }
-          return true;
-        });
+        client.addTelemetryProcessor(keepFailuresTelemetryProcessor);
       }
 
       client.trackTrace({message: 'App insights activated'});

--- a/src/test/unit/modules/appinsights/index.test.ts
+++ b/src/test/unit/modules/appinsights/index.test.ts
@@ -1,0 +1,94 @@
+import config from 'config';
+
+const mockStart = jest.fn();
+const mockSetSendLiveMetrics = jest.fn(() => ({start: mockStart}));
+const mockAddTelemetryProcessor = jest.fn();
+const mockTrackTrace = jest.fn();
+const mockClient = {
+  context: {tags: {} as Record<string, string>, keys: {cloudRole: 'ai.cloud.role'}},
+  config: {samplingPercentage: undefined as number | undefined},
+  addTelemetryProcessor: mockAddTelemetryProcessor,
+  trackTrace: mockTrackTrace,
+};
+
+jest.mock('applicationinsights', () => ({
+  setup: jest.fn(() => ({setSendLiveMetrics: mockSetSendLiveMetrics})),
+  defaultClient: mockClient,
+}));
+
+jest.mock('config');
+
+import {AppInsights, keepFailuresTelemetryProcessor} from 'modules/appinsights';
+
+const mockConfigGet = config.get as jest.Mock;
+
+const envelope = (baseType: string, success?: boolean) => ({
+  sampleRate: 1,
+  data: {baseType, baseData: {success}},
+});
+
+describe('AppInsights module', () => {
+  const ORIGINAL_ENV = process.env.LAUNCH_DARKLY_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.config.samplingPercentage = undefined;
+    mockClient.context.tags = {};
+    mockConfigGet.mockReturnValue('test-instrumentation-key');
+  });
+
+  afterAll(() => {
+    process.env.LAUNCH_DARKLY_ENV = ORIGINAL_ENV;
+  });
+
+  describe('keepFailuresTelemetryProcessor', () => {
+    it('forces sampleRate to 100 for exceptions', () => {
+      const env = envelope('ExceptionData');
+      expect(keepFailuresTelemetryProcessor(env)).toBe(true);
+      expect(env.sampleRate).toBe(100);
+    });
+
+    it('forces sampleRate to 100 for failed requests', () => {
+      const env = envelope('RequestData', false);
+      keepFailuresTelemetryProcessor(env);
+      expect(env.sampleRate).toBe(100);
+    });
+
+    it('forces sampleRate to 100 for failed dependencies', () => {
+      const env = envelope('RemoteDependencyData', false);
+      keepFailuresTelemetryProcessor(env);
+      expect(env.sampleRate).toBe(100);
+    });
+
+    it('leaves successful requests unchanged', () => {
+      const env = envelope('RequestData', true);
+      keepFailuresTelemetryProcessor(env);
+      expect(env.sampleRate).toBe(1);
+    });
+  });
+
+  describe('enable', () => {
+    it('disables sampling and registers the failure-keeping processor in non-prod', () => {
+      process.env.LAUNCH_DARKLY_ENV = 'perftest';
+      new AppInsights().enable();
+      expect(mockClient.config.samplingPercentage).toBe(100);
+      expect(mockAddTelemetryProcessor).toHaveBeenCalledWith(keepFailuresTelemetryProcessor);
+      expect(mockTrackTrace).toHaveBeenCalled();
+    });
+
+    it('leaves sampling untouched in prod', () => {
+      process.env.LAUNCH_DARKLY_ENV = 'prod';
+      new AppInsights().enable();
+      expect(mockClient.config.samplingPercentage).toBeUndefined();
+      expect(mockAddTelemetryProcessor).not.toHaveBeenCalled();
+    });
+
+    it('logs an error and does not start when no instrumentation key is set', () => {
+      mockConfigGet.mockReturnValue(undefined);
+      process.env.LAUNCH_DARKLY_ENV = 'perftest';
+      new AppInsights().enable();
+      expect(mockStart).not.toHaveBeenCalled();
+      expect(mockAddTelemetryProcessor).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What

Disable the ~1% telemetry sampling in **non-prod** App Insights so failures are actually captured. Gated on `LAUNCH_DARKLY_ENV` — **prod is untouched**.

## Why

While diagnosing the perftest `/claim/check-and-send` `Case not found` errors, App Insights for `civil-citizen-ui-perftest` turned out to be sampled at a fixed **1%** (`ItemCount = 100`): over a ~50‑min run (~7,400 requests) only ~74 rows were retained, and **not a single 4xx/5xx or exception survived** across 3 days. The `Case not found` 500s and the failing check-and-send requests were statistically dropped, so the telemetry couldn't confirm the root cause. The app sets no sampling itself and the Azure resource has none configured, so the 1% is imposed by the base chart/image (or a workspace cap).

## Change

In `src/main/modules/appinsights/index.ts`, after `start()`:
- For non-prod (`LAUNCH_DARKLY_ENV !== 'prod'`), set `samplingPercentage = 100`.
- Add a telemetry processor that force-keeps `ExceptionData` and failed `RequestData`/`RemoteDependencyData` (`sampleRate = 100`), so failures survive even if a data cap re-imposes sampling.

Assigning `config.samplingPercentage` after `start()` deterministically overrides whatever currently forces the 1%.

## Prod safety

The entire block is skipped when `LAUNCH_DARKLY_ENV === 'prod'`, keyed off an env var the chart already sets for every environment. No `values.yaml`/helm/flux change, and prod telemetry volume and behaviour are unchanged.

## Verifying after deploy

After a perftest run, confirm sampling is off:
```kql
AppRequests
| where TimeGenerated > ago(1d)
| where _ResourceId has "civil-citizen-ui-perftest"
| summarize by ItemCount
```
`ItemCount = 1` → capturing everything. Still `100` → the source is a **daily data cap** on the `hmcts-nonprod` workspace/`civil-citizen-ui-perftest` component (non-prod), which then needs raising in Azure.