### PR TITLE
DTSCCI-5714: Set App Insights ingestion sampling to 100% on perftest, demo and aat

### DIFF
--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -10,11 +10,11 @@ module "application_insights" {
 
   common_tags = var.common_tags
 
-  # Capture full telemetry on perftest so load-test failures (failed requests, 5xx, exceptions)
-  # are not dropped by the module's default non-prod ingestion sampling of 1%, which blocks
-  # diagnosis of performance runs. Other environments keep the module defaults (prod = 100%,
-  # other non-prod = 1%). See DTSCCI-5714.
-  sampling_percentage = var.env == "perftest" ? 100 : null
+  # Capture full telemetry on the lower environments used for diagnosis (perftest, demo, aat)
+  # so failures (failed requests, 5xx, exceptions) are not dropped by the module's default
+  # non-prod ingestion sampling of 1%, which blocks diagnosis. Remaining environments keep the
+  # module defaults (prod = 100%, other non-prod = 1%). See DTSCCI-5714.
+  sampling_percentage = contains(["perftest", "demo", "aat"], lower(var.env)) ? 100 : null
 }
 
 moved {

--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -9,6 +9,12 @@ module "application_insights" {
   resource_group_name = azurerm_resource_group.rg.name
 
   common_tags = var.common_tags
+
+  # Capture full telemetry on perftest so load-test failures (failed requests, 5xx, exceptions)
+  # are not dropped by the module's default non-prod ingestion sampling of 1%, which blocks
+  # diagnosis of performance runs. Other environments keep the module defaults (prod = 100%,
+  # other non-prod = 1%). See DTSCCI-5714.
+  sampling_percentage = var.env == "perftest" ? 100 : null
 }
 
 moved {


### PR DESCRIPTION
## What

Override App Insights **ingestion** sampling to **100% on perftest, demo and aat** (the lower envs used for diagnosis). Other environments are unchanged.

## Why

The perftest `/claim/check-and-send` `Case not found` failures were undiagnosable because telemetry was sampled at **1%** — failed requests, 5xx and exceptions were statistically dropped.

The 1% is **server-side ingestion sampling** set by the HMCTS `terraform-module-application-insights` module, which defaults all non-prod components to 1%:
```hcl
sampling_map = { prod = 100, prd = 100, idam-prod = 100, ... }
sampling_percentage_default = var.sampling_percentage != null ? var.sampling_percentage
                              : lookup(local.sampling_map, lower(var.env), 1)  # non-prod -> 1
```
Because it's applied at ingestion, the app's SDK-side `samplingPercentage` (merged PR #7832) cannot lift it — confirmed live (`ItemCount=100` persisted on the merged image).

## Change

`infrastructure/app-insights.tf` passes the module's optional `sampling_percentage` input:
```hcl
sampling_percentage = contains(["perftest", "demo", "aat"], lower(var.env)) ? 100 : null
```
The `: null` keeps the module defaults everywhere else (prod = 100%, ithc/preview = 1%).

## Notes

- The three components were already PATCHed to 100% manually so the change is effective now; this Terraform makes it durable so the next `terraform apply` doesn't revert them to 1%.
- **Cost:** aat in particular is continuously exercised by PR/master functional tests, so 100% sampling there is a meaningful, ongoing telemetry-ingestion increase on the shared `hmcts-nonprod` workspace (which has no daily cap). This is a deliberate trade-off for diagnosability — flag if it should be scoped back (e.g. perftest-only, or revert once diagnosis is complete).
- Verify after apply: `ItemCount` for each component should be `1` (unsampled) during traffic.