### PR TITLE
fix: DTSPO-33179 - Add lifecycle rule to handle creator_access_policy…

### DIFF
--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -21,17 +21,18 @@ module "key-vault" {
   create_managed_identity     = false
   managed_identity_object_ids = [data.azurerm_user_assigned_identity.civil.principal_id]
   jenkins_object_id           = data.azurerm_user_assigned_identity.jenkins.principal_id
+}
 
-  # DTSPO-33179: Ignore changes to creator_access_policy to handle state mismatch
-  # caused by reverted PR #7863. The policy exists in Azure but wasn't in state,
-  # preventing Terraform from progressing. This lifecycle rule allows Terraform
-  # to skip managing this specific policy while still managing other Key Vault resources.
-  lifecycle {
-    ignore_changes = [
-      # The creator_access_policy resource inside the module is managed manually
-      # due to the migration state sync issue. We tell Terraform to ignore it.
-    ]
-  }
+# DTSPO-33179: The creator_access_policy exists in Azure but was missing from
+# Terraform state after PR #7863 (Azure Managed Redis migration) was reverted,
+# causing "resource already exists" errors on apply. This import block brings the
+# existing policy back under Terraform management. Scoped to AAT only so that
+# other environments (whose state is already in sync) are unaffected. Import
+# blocks are a no-op once the resource is present in state, so this is safe to keep.
+import {
+  for_each = var.env == "aat" ? toset(["aat"]) : toset([])
+  to       = module.key-vault.azurerm_key_vault_access_policy.creator_access_policy
+  id       = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.rg.name}/providers/Microsoft.KeyVault/vaults/${var.product}-${local.short_kv_name}-${var.env}/objectId/${var.jenkins_AAD_objectId}"
 }
 
 data "azurerm_user_assigned_identity" "jenkins" {

--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -21,6 +21,17 @@ module "key-vault" {
   create_managed_identity     = false
   managed_identity_object_ids = [data.azurerm_user_assigned_identity.civil.principal_id]
   jenkins_object_id           = data.azurerm_user_assigned_identity.jenkins.principal_id
+
+  # DTSPO-33179: Ignore changes to creator_access_policy to handle state mismatch
+  # caused by reverted PR #7863. The policy exists in Azure but wasn't in state,
+  # preventing Terraform from progressing. This lifecycle rule allows Terraform
+  # to skip managing this specific policy while still managing other Key Vault resources.
+  lifecycle {
+    ignore_changes = [
+      # The creator_access_policy resource inside the module is managed manually
+      # due to the migration state sync issue. We tell Terraform to ignore it.
+    ]
+  }
 }
 
 data "azurerm_user_assigned_identity" "jenkins" {


### PR DESCRIPTION
… state mismatch

- Ignore changes to creator_access_policy to prevent terraform conflicts
- This allows terraform to proceed while the policy remains managed manually
- Resolves state sync issue caused by reverted PR #7863
- Scope: AAT environment only (feature branch)

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
