### PR TITLE
DTSCCI-00000: Removed notification text validation as this is undertaken in civil-service unit tests

### DIFF
--- a/src/test/functionalTests/tests/ui_tests/reject-all/LipvLip_RejectAll_AlreadyPaid_InFull_tests.js
+++ b/src/test/functionalTests/tests/ui_tests/reject-all/LipvLip_RejectAll_AlreadyPaid_InFull_tests.js
@@ -9,17 +9,10 @@ const {
 const {
   verifyNotificationTitleAndContent,
 } = require('../../../specClaimHelpers/e2e/dashboardHelper');
-// eslint-disable-next-line no-unused-vars
-const yesIWantMoretime = 'yesIWantMoretime';
-const {
-  defendantResponseFullDefenceAlreadyPaid,
-} = require('../../../specClaimHelpers/dashboardNotificationConstants');
-const { formattedDate } = require('../../../specClaimHelpers/api/dataHelper');
+
 let claimRef, claimType;
 let caseData;
 let claimNumber, defendantName;
-const defaultRespondTime = '4pm';
-const applicant1ResponseDeadlineEn = formattedDate(29);
 
 Feature(
   'Response with RejectAll-AlreadyPaid-InFull - Small Claims & Fast Track',
@@ -51,22 +44,7 @@ Scenario(
       config.claimantCitizenUser.email,
       config.claimantCitizenUser.password,
     );
-    const claimSettledAmount = '£1500';
-    const claimSettledDateEn = '2 March 2023';
-    const defendantNotification = defendantResponseFullDefenceAlreadyPaid(
-      claimSettledAmount,
-      claimSettledDateEn,
-      defaultRespondTime,
-      applicant1ResponseDeadlineEn,
-    );
-    console.log('title:', defendantNotification.title);
-    console.log('content:', defendantNotification.content);
-    await verifyNotificationTitleAndContent(
-      claimNumber,
-      defendantNotification.title,
-      defendantNotification.content,
-    );
-    // One of the step in the below method is commented until https://tools.hmcts.net/jira/browse/CIV-13496 is fixed
+
     await ResponseToDefenceLipVsLipSteps.ResponseToDefenceStepsAsAnAcceptanceOfFullDefenceAlreadyPaidInFull(
       claimRef,
       claimNumber,
@@ -101,21 +79,6 @@ Scenario(
     await LoginSteps.EnterCitizenCredentials(
       config.claimantCitizenUser.email,
       config.claimantCitizenUser.password,
-    );
-    const claimSettledAmount = '£15000';
-    const claimSettledDateEn = '1 February 2020';
-    const defendantNotification = defendantResponseFullDefenceAlreadyPaid(
-      claimSettledAmount,
-      claimSettledDateEn,
-      defaultRespondTime,
-      applicant1ResponseDeadlineEn,
-    );
-    console.log('title:', defendantNotification.title);
-    console.log('content:', defendantNotification.content);
-    await verifyNotificationTitleAndContent(
-      claimNumber,
-      defendantNotification.title,
-      defendantNotification.content,
     );
 
     await ResponseToDefenceLipVsLipSteps.ResponseToDefenceStepsAsAnRejectionOfFullDefenceAlreadyPaidInFull(


### PR DESCRIPTION
Nightly test is failing due to notification showing different dates to what the test expects.
The test for checking the notification text is already being done in the civil-service unit tests and so is not required in the codeceptjs test.
Also, the test has not implemented the response deadline date logic that is held with the civil-service code base and will fail when the date falls on a weekend or bank holiday.