### PR TITLE
DTSCCI-5961: set Node keepAliveTimeout above Traefik idle timeout to fix intermittent 502s

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -28,6 +28,13 @@ process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
   
 });
 
+// Node's default keepAliveTimeout (5s) is below Traefik's 90s backend idleConnTimeout, so Node
+// closes pooled keep-alive sockets Traefik still reuses toward the pod -> RST -> intermittent 502.
+// Hold the socket open past Traefik's idle timeouts (90s backend, 180s front) so Traefik is always
+// the side that closes first. headersTimeout is intentionally left at the Node default (60s): it
+// caps time-to-receive request headers, not idle keep-alive, and the two are decoupled in Node 24.
+const keepAliveTimeout = 185000;
+
 if (app.locals.ENV === 'development') {
   const sslDirectory = path.join(__dirname, 'resources', 'localhost-ssl');
   const sslOptions = {
@@ -35,11 +42,13 @@ if (app.locals.ENV === 'development') {
     key: readFileSync(path.join(sslDirectory, 'localhost.key')),
   };
   const server = createServer(sslOptions, app);
+  server.keepAliveTimeout = keepAliveTimeout;
   server.listen(port, () => {
     logger.info(`Application started: https://localhost:${port}`);
   });
 } else {
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     logger.info(`Application started: http://localhost:${port}`);
   });
+  server.keepAliveTimeout = keepAliveTimeout;
 }


### PR DESCRIPTION
Node's default keepAliveTimeout (5s) is below Traefik's 90s backend idleConnTimeout, so Node closes pooled sockets Traefik still reuses toward the pod, returning intermittent 502s. Set keepAliveTimeout=185000 on the http.Server so Traefik closes idle connections first. headersTimeout left at the Node 24 default (60s) - it governs header receipt, not idle keep-alive.
