### PR TITLE
DTSCCI-6075 Fix nanoid audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "form-data": "4.0.6",
     "import-in-the-middle": "^1.14.4",
     "tmp": "^0.2.7",
-    "nanoid": "^3.3.8",
+    "nanoid": "^3.3.18",
     "@babel/traverse": "^7.26.5",
     "cross-spawn": "7.0.6",
     "express": "5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10395,12 +10395,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:^3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/6eec280694e2088d18fb802b1e3bfc4578e27b665b7ecfbe36c7356612fea2f814277056e671e2a1529dff551588a652efdc0bfa39f8a3185bc2247be311872e
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- raise the nanoid resolution from 3.3.8 to 3.3.18
- refresh the Yarn lockfile so postcss resolves the patched nanoid release
- keep the existing audit suppression file unchanged

## Verification

- Jenkins Yarn audit wrapper passes with only the existing crypto-js suppression
- `yarn install --immutable`
- `yarn build`
- `git diff --check`

## Jira

[DTSCCI-6075](https://tools.hmcts.net/jira/browse/DTSCCI-6075)